### PR TITLE
Fixing Mkdocs Deployment 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,11 +56,11 @@ jobs:
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v4
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for documentation deployment by downgrading the versions of two actions used in the process.

### Workflow configuration changes:
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL59-R63): Downgraded `actions/configure-pages` from version `v5` to `v4`.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL59-R63): Downgraded `actions/upload-pages-artifact` from version `v4` to `v3`.