### PR TITLE
fixed

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
     - Agents: conscious-ingestion/agents.md
   - Examples:
     - Basic Usage: examples/basic-usage.md
+    - DigitalOcean Integration: examples/digital-ocean-integration.md
+    - Swarms Integration: examples/swarms-integration.md
   - Contributing: contributing.md
 
 extra:


### PR DESCRIPTION
This pull request adds new documentation links to the navigation menu in `mkdocs.yml`, expanding the list of integration examples.

Documentation updates:

* Added "DigitalOcean Integration" and "Swarms Integration" example links under the "Examples" section in the navigation (`mkdocs.yml`).