### PR TITLE
PR #117 : Added bounds feature for memory validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ memori = Memori(
     database_connect="sqlite:///my_memory.db",
     template="basic", 
     conscious_ingest=True,  # One-shot context injection
+    conscious_memory_limit=100,  # Must be an integer between 1 and 500
     openai_api_key="sk-..."
 )
 

--- a/memori/core/memory.py
+++ b/memori/core/memory.py
@@ -111,9 +111,13 @@ class Memori:
         self.schema_init = schema_init
         self.database_prefix = database_prefix
         self.database_suffix = database_suffix
+
         # Validate conscious_memory_limit parameter
-        if not isinstance(conscious_memory_limit, int) or conscious_memory_limit < 1:
-            raise ValueError("conscious_memory_limit must be a positive integer")
+        if not isinstance(conscious_memory_limit, int):
+            raise TypeError("conscious_memory_limit must be an integer")
+
+        if not (1 <= conscious_memory_limit <= 500):
+            raise ValueError("conscious_memory_limit must be between 1 and 500")
 
         self.conscious_memory_limit = conscious_memory_limit
 

--- a/tests/test_memory_validation.py
+++ b/tests/test_memory_validation.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Add the root project folder to the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from memori.core.memory import Memori
+
+def test_conscious_memory_limit_valid_values():
+    """Valid conscious_memory_limit values should not raise errors"""
+    try:
+        Memori(conscious_memory_limit=1)
+        Memori(conscious_memory_limit=250)
+        Memori(conscious_memory_limit=500)
+    except Exception as e:
+        pytest.fail(f"Unexpected exception raised: {e}")
+
+def test_conscious_memory_limit_invalid_low():
+    """Values below 1 should raise ValueError"""
+    with pytest.raises(ValueError):
+        Memori(conscious_memory_limit=0)
+
+def test_conscious_memory_limit_invalid_high():
+    """Values above 500 should raise ValueError"""
+    with pytest.raises(ValueError):
+        Memori(conscious_memory_limit=1000)
+
+def test_conscious_memory_limit_invalid_type():
+    """Non-integer types should raise TypeError"""
+    with pytest.raises(TypeError):
+        Memori(conscious_memory_limit="high")
+


### PR DESCRIPTION
#  Added Bounds Feature for Memory Validation

##  Problem
The `conscious_memory_limit` parameter in `memori/core/memory.py` was only validated to be a positive integer, but lacked an upper bound. Extremely large values could degrade performance and cause unexpected behavior.

## Feature Added
- Added validation to ensure `conscious_memory_limit` is **an integer between 1 and 500**.
- Invalid values below 1 or above 500 raise a `ValueError`.
- Non-integer values raise a `TypeError`.
- Updated tests in `tests/test_memory_validation.py` to cover:
  - Valid values within the range.
  - Values below 1.
  - Values above 500.
  - Non-integer types.

```python
# Example validation added in Memori class
if not isinstance(conscious_memory_limit, int):
    raise TypeError("conscious_memory_limit must be an integer")

if not (1 <= conscious_memory_limit <= 500):
    raise ValueError("conscious_memory_limit must be between 1 and 500")
```
# Test Code + Output Screenshot : 

```python
import sys
from pathlib import Path
import pytest

# Add the root project folder to the Python path
sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

from memori.core.memory import Memori

def test_conscious_memory_limit_valid_values():
    """Valid conscious_memory_limit values should not raise errors"""
    try:
        Memori(conscious_memory_limit=1)
        Memori(conscious_memory_limit=250)
        Memori(conscious_memory_limit=500)
    except Exception as e:
        pytest.fail(f"Unexpected exception raised: {e}")

def test_conscious_memory_limit_invalid_low():
    """Values below 1 should raise ValueError"""
    with pytest.raises(ValueError):
        Memori(conscious_memory_limit=0)

def test_conscious_memory_limit_invalid_high():
    """Values above 500 should raise ValueError"""
    with pytest.raises(ValueError):
        Memori(conscious_memory_limit=1000)

def test_conscious_memory_limit_invalid_type():
    """Non-integer types should raise TypeError"""
    with pytest.raises(TypeError):
        Memori(conscious_memory_limit="high")
```

## Screenshot : 

<img width="1451" height="91" alt="image" src="https://github.com/user-attachments/assets/00d9d70d-3fb9-474c-8dff-b16b0168cb21" />
