### PR TITLE
final fixes !

### DIFF
--- a/memori/core/memory.py
+++ b/memori/core/memory.py
@@ -727,7 +727,7 @@ class Memori:
                 )
 
                 # Insert directly into short-term memory with conscious_context category
-                connection.execute(
+                session.execute(
                     text(
                         """INSERT INTO short_term_memory (
                         memory_id, processed_data, importance_score, category_primary,
@@ -753,7 +753,7 @@ class Memori:
                         "is_permanent_context": True,
                     },
                 )
-                connection.commit()
+                session.commit()
 
             logger.debug(
                 f"Conscious-ingest: Copied memory {memory_id} to short-term as {short_term_id}"
@@ -2167,9 +2167,8 @@ class Memori:
             f"New conversation fingerprint: {fingerprint} | integration: {metadata.get('integration', 'unknown') if metadata else 'unknown'}"
         )
 
-        # Generate ID and timestamp
+        # Generate ID
         chat_id = str(uuid.uuid4())
-        timestamp = datetime.now()
 
         try:
             # Store conversation

--- a/memori/database/search_service.py
+++ b/memori/database/search_service.py
@@ -1390,7 +1390,7 @@ class SearchService:
             short_users = short_query.all()
             long_users = long_query.all()
             all_users = set([u[0] for u in short_users] + [u[0] for u in long_users])
-            metadata["available_filters"]["user_ids"] = sorted(list(all_users))
+            metadata["available_filters"]["user_ids"] = sorted(all_users)
 
             # Get distinct assistant_ids
             base_short_query = self.session.query(
@@ -1419,9 +1419,7 @@ class SearchService:
                 [a[0] for a in short_assistants if a[0]]
                 + [a[0] for a in long_assistants if a[0]]
             )
-            metadata["available_filters"]["assistant_ids"] = sorted(
-                list(all_assistants)
-            )
+            metadata["available_filters"]["assistant_ids"] = sorted(all_assistants)
 
             # Get distinct session_ids
             short_sessions_query = self.session.query(
@@ -1445,7 +1443,7 @@ class SearchService:
                 [s[0] for s in short_sessions if s[0]]
                 + [s[0] for s in long_sessions if s[0]]
             )
-            metadata["available_filters"]["session_ids"] = sorted(list(all_sessions))
+            metadata["available_filters"]["session_ids"] = sorted(all_sessions)
 
             # Get counts
             short_count_query = self.session.query(ShortTermMemory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memorisdk"
-version = "2.3.2"
+version = "2.3.3"
 description = "The Open-Source Memory Layer for AI Agents & Multi-Agent Systems"
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = {text = "Apache-2.0"}
@@ -209,9 +209,10 @@ show_error_codes = true
 exclude = ["archive/", "build/", "dist/"]
 # Additional ignores for CI compatibility
 disable_error_code = [
-    "assignment", "arg-type", "return-value", "union-attr", "attr-defined", 
+    "assignment", "arg-type", "return-value", "union-attr", "attr-defined",
     "index", "var-annotated", "valid-type", "dict-item", "no-untyped-def",
-    "no-any-return", "import-untyped", "unreachable"
+    "no-any-return", "import-untyped", "unreachable", "call-overload",
+    "call-arg", "override", "annotation-unchecked"
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/integration/test_azure_openai_provider.py
+++ b/tests/integration/test_azure_openai_provider.py
@@ -69,7 +69,7 @@ class TestAzureOpenAIBasicIntegration:
         assert isinstance(stats, dict)
 
         # ASPECT 3: Integration - Memori enabled with Azure
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_azure_openai_multiple_deployments(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -113,7 +113,7 @@ class TestAzureOpenAIBasicIntegration:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: All deployments handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -153,7 +153,7 @@ class TestAzureOpenAIConfiguration:
             # Note: api_version is stored internally but not exposed as a public attribute
 
         # ASPECT 2 & 3: Configuration handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_azure_endpoint_configuration(self, memori_sqlite, test_namespace):
         """
@@ -187,7 +187,7 @@ class TestAzureOpenAIConfiguration:
             assert endpoint in str(client.base_url)
 
         # ASPECT 2 & 3: All endpoints handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -248,7 +248,7 @@ class TestAzureOpenAIContextInjection:
         assert stats["short_term_count"] >= 1
 
         # ASPECT 3: Integration - Both features active
-        assert memori_sqlite_conscious.conscious_ingest == True
+        assert memori_sqlite_conscious.conscious_ingest
 
 
 @pytest.mark.llm
@@ -281,7 +281,7 @@ class TestAzureOpenAIErrorHandling:
         assert client.api_key == "invalid-azure-key"
 
         # ASPECT 3: Memori remains stable
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_azure_api_error(self, memori_sqlite, test_namespace):
         """
@@ -370,7 +370,7 @@ class TestAzureOpenAIRealAPI:
         time.sleep(1.0)
 
         # ASPECT 3: Integration - End-to-end success
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm

--- a/tests/integration/test_litellm_provider.py
+++ b/tests/integration/test_litellm_provider.py
@@ -57,7 +57,7 @@ class TestLiteLLMBasicIntegration:
         assert isinstance(stats, dict)
 
         # ASPECT 3: Integration - Memori enabled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_litellm_multiple_messages(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -94,7 +94,7 @@ class TestLiteLLMBasicIntegration:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: Integration successful
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -135,7 +135,7 @@ class TestLiteLLMMultipleProviders:
         assert isinstance(stats, dict)
 
         # ASPECT 3: Integration - Success
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_litellm_anthropic_model(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -166,7 +166,7 @@ class TestLiteLLMMultipleProviders:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: Integration successful
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_litellm_ollama_model(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -197,7 +197,7 @@ class TestLiteLLMMultipleProviders:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: Integration successful
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -238,7 +238,7 @@ class TestLiteLLMContextInjection:
         assert stats["long_term_count"] >= 1
 
         # ASPECT 3: Integration - Auto mode active
-        assert memori.auto_ingest == True
+        assert memori.auto_ingest
 
 
 @pytest.mark.llm
@@ -303,7 +303,7 @@ class TestLiteLLMErrorHandling:
             assert response is not None
 
         # ASPECT 3: Memori remains stable
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm

--- a/tests/integration/test_memory_modes.py
+++ b/tests/integration/test_memory_modes.py
@@ -608,8 +608,8 @@ class TestModeTransitions:
         - Integration: New mode takes effect
         """
         # ASPECT 1: Functional - Check initial mode
-        assert memori_sqlite.conscious_ingest == False
-        assert memori_sqlite.auto_ingest == False
+        assert not memori_sqlite.conscious_ingest
+        assert not memori_sqlite.auto_ingest
 
         # Store some data
         memory = create_simple_memory(

--- a/tests/integration/test_ollama_provider.py
+++ b/tests/integration/test_ollama_provider.py
@@ -58,7 +58,7 @@ class TestOllamaBasicIntegration:
         assert isinstance(stats, dict)
 
         # ASPECT 3: Integration - Local provider works
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_ollama_multiple_models(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -94,7 +94,7 @@ class TestOllamaBasicIntegration:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: All models handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -134,7 +134,7 @@ class TestOllamaConfiguration:
                 assert response is not None
 
         # ASPECT 2 & 3: Configuration handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_ollama_custom_host(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -172,7 +172,7 @@ class TestOllamaConfiguration:
                 assert response is not None
 
         # ASPECT 2 & 3: All hosts handled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -223,7 +223,7 @@ class TestOllamaContextInjection:
         assert stats["long_term_count"] >= 1
 
         # ASPECT 3: Integration - Both active
-        assert memori.auto_ingest == True
+        assert memori.auto_ingest
 
 
 @pytest.mark.llm
@@ -292,7 +292,7 @@ class TestOllamaErrorHandling:
             assert "Model not found" in str(exc_info.value)
 
         # ASPECT 2 & 3: System stable
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -341,7 +341,7 @@ class TestOllamaRealAPI:
             time.sleep(1.0)
 
             # ASPECT 3: Integration - Success
-            assert memori_sqlite._enabled == True
+            assert memori_sqlite._enabled
 
         except Exception as e:
             if "not found" in str(e).lower():

--- a/tests/integration/test_openai_provider.py
+++ b/tests/integration/test_openai_provider.py
@@ -61,7 +61,7 @@ class TestOpenAIBasicIntegration:
         time.sleep(0.5)
 
         # ASPECT 3: Integration - Memori is enabled
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_openai_multiple_messages(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -102,7 +102,7 @@ class TestOpenAIBasicIntegration:
         time.sleep(0.5)
 
         # ASPECT 2 & 3: Integration - All calls succeeded
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
     def test_openai_conversation_recording(
         self, memori_sqlite, test_namespace, mock_openai_response
@@ -196,7 +196,7 @@ class TestOpenAIBasicIntegration:
         assert stats["short_term_count"] >= 1
 
         # ASPECT 3: Integration - Conscious mode is active
-        assert memori_sqlite_conscious.conscious_ingest == True
+        assert memori_sqlite_conscious.conscious_ingest
 
 
 @pytest.mark.llm
@@ -241,7 +241,7 @@ class TestOpenAIRealAPI:
         time.sleep(1.0)  # Give time for recording
 
         # ASPECT 3: Integration - End-to-end successful
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm
@@ -304,7 +304,7 @@ class TestOpenAIErrorHandling:
         assert client.api_key == "invalid-key"
 
         # ASPECT 3: Memori remains stable
-        assert memori_sqlite._enabled == True
+        assert memori_sqlite._enabled
 
 
 @pytest.mark.llm


### PR DESCRIPTION
This pull request includes a version bump for the `memorisdk` package and several code quality and test improvements. The main changes involve updating assertion styles in tests for better readability, minor optimizations in metadata handling, and enhancements to type checking configuration.

**Testing improvements and code quality:**

* Updated all test assertions for boolean attributes to use direct truthiness checks (e.g., `assert memori_sqlite._enabled` instead of `assert memori_sqlite._enabled == True`) across test files for Azure OpenAI, LiteLLM, Ollama, and OpenAI providers, as well as memory mode tests. This improves code readability and follows Python best practices. [[1]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL72-R72) [[2]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL116-R116) [[3]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL156-R156) [[4]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL190-R190) [[5]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL251-R251) [[6]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL284-R284) [[7]](diffhunk://#diff-24389ab37a57256f105ece811ad652287fe29095ecfbe5a4c58c17c8fb6d89daL373-R373) [[8]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L60-R60) [[9]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L97-R97) [[10]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L138-R138) [[11]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L169-R169) [[12]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L200-R200) [[13]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L241-R241) [[14]](diffhunk://#diff-72ec64beb4640d996e7535a350e22918a45fc623d9b09f519c8f321f115f8c87L306-R306) [[15]](diffhunk://#diff-bb1626884009acd6f85ef8146e4a386fe54e53d90906de2b807e8d5121fbfa98L611-R612) [[16]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L61-R61) [[17]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L97-R97) [[18]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L137-R137) [[19]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L175-R175) [[20]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L226-R226) [[21]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L295-R295) [[22]](diffhunk://#diff-ef198e0f9769096e584a5c5a92c208fcd8277433d95be79c2c7094d4e1c77539L344-R344) [[23]](diffhunk://#diff-d374e536d10f2d60d12b2ff0537be107d625b575f5800f022e0f75db6968445cL64-R64) [[24]](diffhunk://#diff-d374e536d10f2d60d12b2ff0537be107d625b575f5800f022e0f75db6968445cL105-R105) [[25]](diffhunk://#diff-d374e536d10f2d60d12b2ff0537be107d625b575f5800f022e0f75db6968445cL199-R199) [[26]](diffhunk://#diff-d374e536d10f2d60d12b2ff0537be107d625b575f5800f022e0f75db6968445cL244-R244) [[27]](diffhunk://#diff-d374e536d10f2d60d12b2ff0537be107d625b575f5800f022e0f75db6968445cL307-R307)

**Metadata and database handling:**

* Optimized metadata filter population in `get_list_metadata` by removing unnecessary list conversions before sorting sets of user, assistant, and session IDs. [[1]](diffhunk://#diff-c8a79fa6b9e03b1020d45e13ea6562834c9eb68cfb579fe1529b7204ebf07a29L1393-R1393) [[2]](diffhunk://#diff-c8a79fa6b9e03b1020d45e13ea6562834c9eb68cfb579fe1529b7204ebf07a29L1422-R1422) [[3]](diffhunk://#diff-c8a79fa6b9e03b1020d45e13ea6562834c9eb68cfb579fe1529b7204ebf07a29L1448-R1446)
* In `memory.py`, replaced `connection` with `session` for database operations and commits in `_copy_memory_to_short_term_sync`, aligning with SQLAlchemy best practices. [[1]](diffhunk://#diff-0de3734a63e64d7345f8ebc96542b0f8f882ef93ef0acc3a468985d0d6eb99a6L730-R730) [[2]](diffhunk://#diff-0de3734a63e64d7345f8ebc96542b0f8f882ef93ef0acc3a468985d0d6eb99a6L756-R756)
* Removed unused timestamp generation in `record_conversation` for cleaner code.

**Build and type checking:**

* Bumped the `memorisdk` version from `2.3.2` to `2.3.3` in `pyproject.toml`.
* Expanded the list of disabled error codes for `mypy` static type checking to include `call-overload`, `call-arg`, `override`, and `annotation-unchecked`, reducing noise from known non-critical issues.