### PR TITLE
Unsupported Error Handling

### DIFF
--- a/memori/llm/_clients.py
+++ b/memori/llm/_clients.py
@@ -381,6 +381,9 @@ class LangChain(BaseClient):
 
                 chatvertexai.prediction_client._memori_installed = True
 
+        if self.config.llm.provider is None:
+            raise RuntimeError("Unsupported LLM client")
+
         return self
 
 

--- a/memori/storage/_registry.py
+++ b/memori/storage/_registry.py
@@ -41,15 +41,12 @@ class Registry:
             if matcher(conn_to_check):
                 return adapter_class(lambda: conn_to_check)
 
-        raise ValueError(
-            f"No adapter registered for connection type: {type(conn_to_check).__module__}"
+        raise RuntimeError(
+            f"Unsupported database: {type(conn_to_check).__module__}.{type(conn_to_check).__name__}"
         )
 
     def driver(self, conn: BaseStorageAdapter):
         dialect = conn.get_dialect()
         if dialect not in self._drivers:
-            raise ValueError(
-                f"No driver registered for dialect: {dialect}. "
-                f"Available dialects: {list(self._drivers.keys())}"
-            )
+            raise RuntimeError(f"Unsupported database dialect: {dialect}")
         return self._drivers[dialect](conn)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memori"
-version = "3.0.4"
+version = "3.0.5"
 description = "Memori Python SDK"
 authors = [{name = "Memori Labs Team", email = "noc@memorilabs.ai"}]
 license = {text = "Apache-2.0"}

--- a/tests/llm/test_llm_registry.py
+++ b/tests/llm/test_llm_registry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from memori.llm._constants import (
     ATHROPIC_LLM_PROVIDER,
     GOOGLE_LLM_PROVIDER,
@@ -33,3 +35,17 @@ def test_llm_google():
 
 def test_llm_openai():
     assert isinstance(Registry().adapter(None, OPENAI_LLM_PROVIDER), OpenAiLlmAdapter)
+
+
+def test_llm_adapter_raises_for_none_provider():
+    """Test that providing None as both provider and title raises RuntimeError."""
+
+    with pytest.raises(RuntimeError, match="Unsupported LLM provider"):
+        Registry().adapter(None, None)
+
+
+def test_llm_adapter_raises_for_unsupported_provider():
+    """Test that providing an unsupported provider raises RuntimeError."""
+
+    with pytest.raises(RuntimeError, match="Unsupported LLM provider"):
+        Registry().adapter("mistral", "mistral")

--- a/tests/storage/test_storage_registry.py
+++ b/tests/storage/test_storage_registry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from memori.storage._registry import Registry
 from memori.storage.adapters.sqlalchemy._adapter import (
     Adapter as SqlAlchemyStorageAdapter,
@@ -43,3 +45,23 @@ def test_storage_driver_cockroachdb(mocker):
     driver = Registry().driver(adapter)
 
     assert isinstance(driver, PostgresqlStorageDriver)
+
+
+def test_storage_adapter_raises_for_unsupported_connection():
+    """Test that unsupported database connection raises RuntimeError."""
+
+    class UnsupportedConnection:
+        pass
+
+    with pytest.raises(RuntimeError, match="Unsupported database"):
+        Registry().adapter(UnsupportedConnection())
+
+
+def test_storage_driver_raises_for_unsupported_dialect(mocker):
+    """Test that unsupported database dialect raises RuntimeError."""
+
+    fake_adapter = mocker.Mock()
+    fake_adapter.get_dialect.return_value = "unsupported_db"
+
+    with pytest.raises(RuntimeError, match="Unsupported database dialect"):
+        Registry().driver(fake_adapter)


### PR DESCRIPTION
Enhance error handling for unsupported LLM clients and database connections. Raise RuntimeError for unsupported LLM providers and database types in the Registry class. Update tests to validate these changes.