### PR TITLE
feat: implement conversation ID caching mechanism in LLM components

### DIFF
--- a/memori/storage/drivers/mongodb/_driver.py
+++ b/memori/storage/drivers/mongodb/_driver.py
@@ -105,6 +105,14 @@ class Conversation(BaseConversation):
 
         return conversation
 
+    def read_id_by_session_id(self, session_id):
+        existing = self.conn.execute(
+            "memori_conversation", "find_one", {"session_id": session_id}
+        )
+        if not existing:
+            return None
+        return existing.get("_id")
+
 
 class ConversationMessage(BaseConversationMessage):
     def create(self, conversation_id: int, role: str, type: str, content: str):
@@ -481,6 +489,12 @@ class Session(BaseSession):
         result = self.conn.execute("memori_session", "insert_one", session_doc)
 
         return result.inserted_id
+
+    def read(self, uuid: str):
+        existing = self.conn.execute("memori_session", "find_one", {"uuid": str(uuid)})
+        if not existing:
+            return None
+        return existing.get("_id")
 
 
 class Schema(BaseSchema):

--- a/memori/storage/drivers/mysql/_driver.py
+++ b/memori/storage/drivers/mysql/_driver.py
@@ -130,6 +130,23 @@ class Conversation(BaseConversation):
 
         return dict(result)
 
+    def read_id_by_session_id(self, session_id) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_conversation
+                 WHERE session_id = %s
+                """,
+                (session_id,),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
+
 
 class ConversationMessage(BaseConversationMessage):
     def create(self, conversation_id: int, role: str, type: str, content: str):
@@ -569,6 +586,23 @@ class Session(BaseSession):
             .fetchone()
             .get("id", None)
         )
+
+    def read(self, uuid: str) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_session
+                 WHERE uuid = %s
+                """,
+                (str(uuid),),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
 
 
 class Schema(BaseSchema):

--- a/memori/storage/drivers/oracle/_driver.py
+++ b/memori/storage/drivers/oracle/_driver.py
@@ -132,6 +132,23 @@ class Conversation(BaseConversation):
 
         return dict(result)
 
+    def read_id_by_session_id(self, session_id) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_conversation
+                 WHERE session_id = :1
+                """,
+                (session_id,),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
+
 
 class ConversationMessage(BaseConversationMessage):
     def create(self, conversation_id: int, role: str, type: str, content: str):
@@ -535,6 +552,23 @@ class Session(BaseSession):
             .fetchone()
             .get("id", None)
         )
+
+    def read(self, uuid: str) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_session
+                 WHERE uuid = :1
+                """,
+                (str(uuid),),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
 
 
 class Schema(BaseSchema):

--- a/memori/storage/drivers/postgresql/_driver.py
+++ b/memori/storage/drivers/postgresql/_driver.py
@@ -130,6 +130,23 @@ class Conversation(BaseConversation):
 
         return dict(result)
 
+    def read_id_by_session_id(self, session_id) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_conversation
+                 WHERE session_id = %s
+                """,
+                (session_id,),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
+
 
 class ConversationMessage(BaseConversationMessage):
     def create(self, conversation_id: int, role: str, type: str, content: str):
@@ -573,6 +590,23 @@ class Session(BaseSession):
             .fetchone()
             .get("id", None)
         )
+
+    def read(self, uuid: str) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_session
+                 WHERE uuid = %s
+                """,
+                (str(uuid),),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
 
 
 class Schema(BaseSchema):

--- a/memori/storage/drivers/sqlite/_driver.py
+++ b/memori/storage/drivers/sqlite/_driver.py
@@ -129,6 +129,23 @@ class Conversation(BaseConversation):
 
         return dict(result)
 
+    def read_id_by_session_id(self, session_id) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_conversation
+                 WHERE session_id = ?
+                """,
+                (session_id,),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
+
 
 class ConversationMessage(BaseConversationMessage):
     def create(self, conversation_id: int, role: str, type: str, content: str):
@@ -526,6 +543,23 @@ class Session(BaseSession):
             .fetchone()
             .get("id", None)
         )
+
+    def read(self, uuid: str) -> int | None:
+        result = (
+            self.conn.execute(
+                """
+                SELECT id
+                  FROM memori_session
+                 WHERE uuid = ?
+                """,
+                (str(uuid),),
+            )
+            .mappings()
+            .fetchone()
+        )
+        if result is None:
+            return None
+        return result.get("id", None)
 
 
 class Schema(BaseSchema):

--- a/tests/llm/test_llm_base.py
+++ b/tests/llm/test_llm_base.py
@@ -796,3 +796,37 @@ def test_inject_conversation_messages_openai_success():
     assert result["messages"][1]["content"] == "Previous answer"
     assert result["messages"][2]["content"] == "New question"
     assert invoke._injected_message_count == 2
+
+
+def test_inject_conversation_messages_cache_miss_loads_from_session(mocker):
+    config = Config()
+    config.session_id = "session-uuid"
+    config.llm.provider = OPENAI_LLM_PROVIDER
+
+    mock_driver = mocker.MagicMock()
+    mock_driver.session.read.return_value = 11
+    mock_driver.conversation.read_id_by_session_id.return_value = 22
+    mock_driver.conversation.messages.read.return_value = [
+        {"role": "user", "content": "Previous question"},
+        {"role": "assistant", "content": "Previous answer"},
+    ]
+
+    mock_storage = mocker.MagicMock()
+    mock_storage.driver = mock_driver
+    config.storage = mock_storage
+
+    invoke = BaseInvoke(config, "test_method")
+    kwargs = {"messages": [{"role": "user", "content": "New question"}]}
+
+    result = invoke.inject_conversation_messages(kwargs)
+
+    assert config.cache.session_id == 11
+    assert config.cache.conversation_id == 22
+    mock_driver.session.read.assert_called_once_with("session-uuid")
+    mock_driver.conversation.read_id_by_session_id.assert_called_once_with(11)
+    mock_driver.conversation.messages.read.assert_called_once_with(22)
+    assert [m["content"] for m in result["messages"]] == [
+        "Previous question",
+        "Previous answer",
+        "New question",
+    ]


### PR DESCRIPTION
- Added `_ensure_cached_conversation_id` method to `BaseInvoke` and `XAiWrappers` classes to handle session and conversation ID caching.
- Updated `inject_conversation_messages` and `inject_conversation_history` methods to utilize the new caching mechanism, ensuring conversation history is loaded correctly when IDs are missing.
- Introduced new methods in storage drivers for reading conversation and session IDs by their respective identifiers across MongoDB, MySQL, Oracle, PostgreSQL, and SQLite drivers.
- Added tests to verify the caching behavior and ensure correct loading of conversation messages from the session.