### PR TITLE
refactor: replace FactCandidates with list of FactCandidate in search…

### DIFF
--- a/memori/search/__init__.py
+++ b/memori/search/__init__.py
@@ -6,20 +6,18 @@ Public entrypoints:
 - find_similar_embeddings
 - search_facts
 - FactCandidate
-- FactCandidates
 - FactSearchResult
 """
 
 from memori.search._api import search_facts
 from memori.search._faiss import find_similar_embeddings
 from memori.search._parsing import parse_embedding
-from memori.search._types import FactCandidate, FactCandidates, FactSearchResult
+from memori.search._types import FactCandidate, FactSearchResult
 
 __all__ = [
     "find_similar_embeddings",
     "parse_embedding",
     "search_facts",
     "FactCandidate",
-    "FactCandidates",
     "FactSearchResult",
 ]

--- a/memori/search/_api.py
+++ b/memori/search/_api.py
@@ -7,7 +7,7 @@ from memori.search._core import (
 )
 from memori.search._faiss import find_similar_embeddings
 from memori.search._lexical import dense_lexical_weights, lexical_scores_for_ids
-from memori.search._types import FactCandidates, FactSearchResult
+from memori.search._types import FactCandidate, FactSearchResult
 
 
 def search_facts(
@@ -18,13 +18,13 @@ def search_facts(
     embeddings_limit: int = 1000,
     *,
     query_text: str | None = None,
-    candidates: FactCandidates | None = None,
+    candidates: list[FactCandidate] | None = None,
 ) -> list[FactSearchResult]:
     """
     Unified search entrypoint.
 
     - DB-backed mode: provide entity_fact_driver, entity_id, query_embedding, embeddings_limit
-    - Pre-scored mode: provide candidates (FactCandidates)
+    - Pre-scored mode: provide candidates (list[FactCandidate])
     """
     if candidates is not None:
         return search_entity_facts_core(

--- a/memori/search/_types.py
+++ b/memori/search/_types.py
@@ -10,11 +10,6 @@ class FactCandidate:
 
 
 @dataclass(frozen=True)
-class FactCandidates:
-    facts: list[FactCandidate]
-
-
-@dataclass(frozen=True)
 class FactSearchResult:
     id: int
     content: str

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,7 +17,6 @@ import numpy as np
 
 from memori.search import (
     FactCandidate,
-    FactCandidates,
     find_similar_embeddings,
     parse_embedding,
     search_facts,
@@ -475,22 +474,20 @@ def test_search_entity_facts_accepts_mapping_rows_for_content(mocker):
 
 
 def test_search_facts_candidates_success():
-    candidates = FactCandidates(
-        facts=[
-            FactCandidate(
-                id=1,
-                content="Fact A",
-                score=0.99,
-                date_created="2026-01-01 10:30:00",
-            ),
-            FactCandidate(
-                id=2,
-                content="Fact B",
-                score=0.5,
-                date_created="2026-01-02 11:15:00",
-            ),
-        ]
-    )
+    candidates = [
+        FactCandidate(
+            id=1,
+            content="Fact A",
+            score=0.99,
+            date_created="2026-01-01 10:30:00",
+        ),
+        FactCandidate(
+            id=2,
+            content="Fact B",
+            score=0.5,
+            date_created="2026-01-02 11:15:00",
+        ),
+    ]
 
     result = search_facts(candidates=candidates, limit=1)
 
@@ -502,22 +499,20 @@ def test_search_facts_candidates_success():
 
 
 def test_search_facts_candidates_can_rerank_with_query_text():
-    candidates = FactCandidates(
-        facts=[
-            FactCandidate(
-                id=1,
-                content="Completely unrelated",
-                score=0.9,
-                date_created="2026-01-01 10:30:00",
-            ),
-            FactCandidate(
-                id=2,
-                content="This mentions blue explicitly",
-                score=0.8,
-                date_created="2026-01-02 11:15:00",
-            ),
-        ]
-    )
+    candidates = [
+        FactCandidate(
+            id=1,
+            content="Completely unrelated",
+            score=0.9,
+            date_created="2026-01-01 10:30:00",
+        ),
+        FactCandidate(
+            id=2,
+            content="This mentions blue explicitly",
+            score=0.8,
+            date_created="2026-01-02 11:15:00",
+        ),
+    ]
 
     result = search_facts(
         candidates=candidates,


### PR DESCRIPTION
… functionality

- Removed the FactCandidates class and updated related code to use a list of FactCandidate instead.
- Adjusted function signatures and internal logic in search_facts and related methods to accommodate the new structure.
- Updated tests to reflect changes in candidate handling, ensuring compatibility with the new list-based approach.