### PR TITLE
Update: Integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,12 +1,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  release:
-    types: [published]
   workflow_dispatch:
   workflow_call:
     secrets:
@@ -30,8 +24,6 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Skip on forks (no secrets available) - tests would be skipped anyway
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       MEMORI_TEST_MODE: "1"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for integration tests. The main change is the removal of automatic triggers for integration tests on pushes, pull requests, and releases, making the workflow now only manually or programmatically triggerable. Additionally, a conditional check for running tests on forks has been removed.

Workflow configuration changes:

* Removed automatic triggers for integration tests on `push`, `pull_request`, and `release` events, so the workflow now only runs on `workflow_dispatch` and `workflow_call` events.
* Removed the conditional check that prevented integration tests from running on forked repositories.