### PR TITLE
Docs: NVIDIA NIM (Nemotron) support without LiteLLM

### DIFF
--- a/docs/features/llm.md
+++ b/docs/features/llm.md
@@ -167,3 +167,35 @@ response = client.chat.completions.create(
     messages=[{"role": "user", "content": "Hello!"}]
 )
 ```
+
+### NVIDIA NIM (OpenAI-compatible)
+
+NVIDIA NIM exposes an OpenAI-compatible Chat Completions endpoint.
+
+- Base URL: `https://integrate.api.nvidia.com/v1/`
+- Docs: https://docs.api.nvidia.com/nim/reference/llm-apis
+
+```python
+import os
+
+from memori import Memori
+from openai import OpenAI
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+engine = create_engine("sqlite:///memori.db")
+SessionLocal = sessionmaker(bind=engine)
+
+client = OpenAI(
+    base_url="https://integrate.api.nvidia.com/v1/",
+    api_key=os.getenv("NVIDIA_API_KEY"),
+)
+
+mem = Memori(conn=SessionLocal).llm.register(client)
+mem.attribution(entity_id="user_123", process_id="my_agent")
+
+response = client.chat.completions.create(
+    model="nvidia-nemotron-4-340b-instruct",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```

--- a/memori/llm/_clients.py
+++ b/memori/llm/_clients.py
@@ -404,6 +404,10 @@ def _detect_platform(client):
         base_url = str(client.base_url).lower()
         if "nebius" in base_url:
             return "nebius"
+        # NVIDIA NIM exposes an OpenAI-compatible API.
+        # https://docs.api.nvidia.com/nim/reference/llm-apis
+        if "integrate.api.nvidia.com" in base_url:
+            return "nvidia_nim"
     return None
 
 


### PR DESCRIPTION
Adds first-class documentation for using NVIDIA NIM (Nemotron, etc.) with Memori *without* LiteLLM.

NIM exposes an OpenAI-compatible endpoint at `https://integrate.api.nvidia.com/v1/` (see https://docs.api.nvidia.com/nim/reference/llm-apis), so users can use the standard OpenAI Python client with `base_url=...`.

This PR:
- Adds a `NVIDIA NIM (OpenAI-compatible)` section to `docs/features/llm.md` with a copy/paste example.
- Extends platform detection to mark clients pointing at `integrate.api.nvidia.com` as `nvidia_nim`.

Net effect: users can use Nemotron and other NIM-hosted models with the normal `Memori(...).llm.register(OpenAI(...))` flow.
