### PR TITLE
Docs: add Anthropic example + helper (not OpenAI-only)

### DIFF
--- a/docs/features/llm.md
+++ b/docs/features/llm.md
@@ -143,6 +143,39 @@ mem.attribution(entity_id="user_123", process_id="pydantic_agent")
 result = agent.run_sync("Hello")
 ```
 
+### Anthropic
+
+```python
+import os
+
+from anthropic import Anthropic
+from memori import Memori
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+engine = create_engine("sqlite:///memori.db")
+SessionLocal = sessionmaker(bind=engine)
+
+client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+
+mem = Memori(conn=SessionLocal).llm.register(client)
+mem.attribution(entity_id="user_123", process_id="my_agent")
+
+response = client.messages.create(
+    model="claude-3-5-sonnet-latest",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+```
+
+#### Convenience helper
+
+```python
+from memori.integrations.anthropic_client import anthropic_client
+
+client = anthropic_client()  # uses ANTHROPIC_API_KEY
+```
+
 ### Nebius AI Studio
 
 ```python

--- a/memori/integrations/anthropic_client.py
+++ b/memori/integrations/anthropic_client.py
@@ -1,0 +1,40 @@
+"""Anthropic integration helper.
+
+Memori already supports the official `anthropic` Python SDK via `Memori(...).llm.register(client)`.
+
+This module provides a small convenience helper for first-time users so they don't
+feel like everything is "OpenAI-only".
+
+Usage:
+
+```python
+from memori.integrations.anthropic_client import anthropic_client
+from memori import Memori
+
+client = anthropic_client()  # uses ANTHROPIC_API_KEY
+mem = Memori(conn=...).llm.register(client)
+```
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def anthropic_client(*, api_key: str | None = None, **kwargs: Any):
+    """Create an Anthropic client using `ANTHROPIC_API_KEY` by default."""
+    try:
+        from anthropic import Anthropic
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError(
+            "Anthropic Python SDK is required. Install with: pip install anthropic"
+        ) from e
+
+    api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is not set. Set it in your environment or pass api_key=."
+        )
+
+    return Anthropic(api_key=api_key, **kwargs)


### PR DESCRIPTION
Adds explicit Anthropic support to docs (and a small convenience helper) so users don’t feel like Memori is "OpenAI-only".

Memori already supports the official `anthropic` SDK via `Memori(...).llm.register(client)`. This PR:
- Adds an Anthropic example to `docs/features/llm.md` (using `ANTHROPIC_API_KEY`).
- Adds `memori.integrations.anthropic_client.anthropic_client()` helper to create a correctly configured `Anthropic(...)` client.

This is additive and keeps existing OpenAI/LiteLLM/OpenAI-compatible flows unchanged.
