### PR TITLE
feat: introduce UnsupportedLLMProviderError for better error handling

### DIFF
--- a/memori/__init__.py
+++ b/memori/__init__.py
@@ -19,6 +19,7 @@ from memori._config import Config
 from memori._exceptions import (
     MissingMemoriApiKeyError,
     QuotaExceededError,
+    UnsupportedLLMProviderError,
     warn_if_legacy_memorisdk_installed,
 )
 from memori.embeddings import embed_texts
@@ -33,7 +34,7 @@ from memori.memory.augmentation import Manager as AugmentationManager
 from memori.memory.recall import Recall
 from memori.storage import Manager as StorageManager
 
-__all__ = ["Memori", "QuotaExceededError"]
+__all__ = ["Memori", "QuotaExceededError", "UnsupportedLLMProviderError"]
 
 warn_if_legacy_memorisdk_installed()
 

--- a/memori/_exceptions.py
+++ b/memori/_exceptions.py
@@ -60,6 +60,15 @@ class MissingMemoriApiKeyError(RuntimeError):
         )
 
 
+class UnsupportedLLMProviderError(RuntimeError):
+    """Raised when an unsupported LLM provider is used."""
+
+    def __init__(self, provider: str):
+        super().__init__(
+            f"Unsupported LLM provider: {provider}. Please see the documentation for supported providers: https://memorilabs.ai/docs/features/llm"
+        )
+
+
 class MemoriLegacyPackageWarning(UserWarning):
     """Warning emitted when the legacy `memorisdk` package is installed."""
 

--- a/tests/llm/test_llm_registry.py
+++ b/tests/llm/test_llm_registry.py
@@ -1,5 +1,6 @@
 import pytest
 
+from memori._exceptions import UnsupportedLLMProviderError
 from memori.llm._constants import (
     ATHROPIC_LLM_PROVIDER,
     GOOGLE_LLM_PROVIDER,
@@ -38,17 +39,30 @@ def test_llm_openai():
 
 
 def test_llm_adapter_raises_for_none_provider():
-    """Test that providing None as both provider and title raises RuntimeError."""
+    """Test that providing None as both provider and title raises UnsupportedLLMProviderError."""
 
-    with pytest.raises(RuntimeError, match="Unsupported LLM provider"):
+    with pytest.raises(UnsupportedLLMProviderError, match="Unsupported LLM provider"):
         Registry().adapter(None, None)
 
 
 def test_llm_adapter_raises_for_unsupported_provider():
-    """Test that providing an unsupported provider raises RuntimeError."""
+    """Test that providing an unsupported provider raises UnsupportedLLMProviderError."""
 
-    with pytest.raises(RuntimeError, match="Unsupported LLM provider"):
+    with pytest.raises(UnsupportedLLMProviderError, match="Unsupported LLM provider"):
         Registry().adapter("mistral", "mistral")
+
+
+def test_llm_client_raises_for_unsupported_client_type():
+    """Test that registering an unsupported direct client raises UnsupportedLLMProviderError."""
+
+    class MockUnsupportedClient:
+        pass
+
+    MockUnsupportedClient.__module__ = "some_unknown.llm"
+    MockUnsupportedClient.__name__ = "UnsupportedClient"
+
+    with pytest.raises(UnsupportedLLMProviderError):
+        Registry().client(MockUnsupportedClient(), None)
 
 
 def test_llm_client_raises_helpful_error_for_langchain():


### PR DESCRIPTION
- Added UnsupportedLLMProviderError exception to handle unsupported LLM providers more gracefully.
- Updated the Registry class to raise this new exception instead of a generic RuntimeError when an unsupported client type is registered.
- Enhanced tests to verify the correct behavior of the new exception in various scenarios, ensuring clearer error messages for unsupported providers.