### PR TITLE
feat: introduce UnsupportedDatabaseError for improved error handling

### DIFF
--- a/memori/_exceptions.py
+++ b/memori/_exceptions.py
@@ -69,6 +69,20 @@ class UnsupportedLLMProviderError(RuntimeError):
         )
 
 
+class UnsupportedDatabaseError(RuntimeError):
+    """Raised when an unsupported database is used."""
+
+    def __init__(self, database: str | None = None):
+        msg = (
+            "Unsupported database."
+            if database is None
+            else f"Unsupported database: {database}."
+        )
+        super().__init__(
+            f"{msg} Please see the documentation for supported databases: https://memorilabs.ai/docs/features/databases"
+        )
+
+
 class MemoriLegacyPackageWarning(UserWarning):
     """Warning emitted when the legacy `memorisdk` package is installed."""
 

--- a/memori/storage/_registry.py
+++ b/memori/storage/_registry.py
@@ -11,6 +11,7 @@ r"""
 from collections.abc import Callable
 from typing import Any
 
+from memori._exceptions import UnsupportedDatabaseError
 from memori.storage._base import BaseStorageAdapter
 
 
@@ -57,9 +58,7 @@ class Registry:
             if matcher(conn_for_match):
                 return adapter_class(lambda: conn_to_check)
 
-        raise RuntimeError(
-            f"Unsupported database: {type(conn_for_match).__module__}.{type(conn_for_match).__name__}"
-        )
+        raise UnsupportedDatabaseError()
 
     def driver(self, conn: BaseStorageAdapter):
         dialect = conn.get_dialect()

--- a/tests/storage/test_storage_registry.py
+++ b/tests/storage/test_storage_registry.py
@@ -1,5 +1,6 @@
 import pytest
 
+from memori._exceptions import UnsupportedDatabaseError
 from memori.storage._registry import Registry
 from memori.storage.adapters.sqlalchemy._adapter import (
     Adapter as SqlAlchemyStorageAdapter,
@@ -58,12 +59,12 @@ def test_storage_driver_oceanbase(mocker):
 
 
 def test_storage_adapter_raises_for_unsupported_connection():
-    """Test that unsupported database connection raises RuntimeError."""
+    """Test that unsupported database connection raises UnsupportedDatabaseError."""
 
     class UnsupportedConnection:
         pass
 
-    with pytest.raises(RuntimeError, match="Unsupported database"):
+    with pytest.raises(UnsupportedDatabaseError, match=r"Unsupported database"):
         Registry().adapter(UnsupportedConnection())
 
 


### PR DESCRIPTION
- Added UnsupportedDatabaseError exception to handle unsupported database connections more gracefully.
- Updated the Registry class to raise this new exception instead of a generic RuntimeError when an unsupported database is encountered.
- Modified tests to verify that UnsupportedDatabaseError is raised with appropriate messages for unsupported connections.