### PR TITLE
chore: Update CI workflow to include Python versions 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Added support for Python versions 3.13 and 3.14 in the CI workflow matrix to ensure compatibility with the latest releases.