### PR TITLE
Fixed package.json deps and axon update

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.1-beta",
+  "version": "0.1.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.1-beta",
+      "version": "0.1.2-beta",
       "license": "Apache-2.0",
       "dependencies": {
-        "@memorilabs/axon": "^0.1.2-beta"
+        "@memorilabs/axon": "^0.1.3-beta"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
+        "@anthropic-ai/sdk": "*",
         "@eslint/js": "^9.0.0",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^2.1.9",
@@ -21,7 +21,7 @@
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.1.8",
         "lint-staged": "^15.0.0",
-        "openai": "^4.0.0",
+        "openai": "*",
         "prettier": "^3.0.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.0.0",
@@ -31,8 +31,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
-        "openai": "^4.0.0"
+        "@anthropic-ai/sdk": "*",
+        "openai": "*"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -800,16 +800,16 @@
       }
     },
     "node_modules/@memorilabs/axon": {
-      "version": "0.1.2-beta",
-      "resolved": "https://registry.npmjs.org/@memorilabs/axon/-/axon-0.1.2-beta.tgz",
-      "integrity": "sha512-LHL9dnI/gKQoe8Rt/JLwvjB5wxmqncH3ZSzH9iLJSdn9aKFjHCwlI2qyTQ3l6Zu5amLsCmRZnMvxu19LG5ionw==",
+      "version": "0.1.3-beta",
+      "resolved": "https://registry.npmjs.org/@memorilabs/axon/-/axon-0.1.3-beta.tgz",
+      "integrity": "sha512-9bFTTyaE6hrT8MGx5Sl3b+PO0SFapNgBvWoGlPFQAhE0b4nCCxA5R70fd44WowJaHgfgIO7TFCCnfLHiZH3Vzg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.74.0",
-        "openai": "^4.0.0"
+        "@anthropic-ai/sdk": "*",
+        "openai": "*"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.1-beta",
+  "version": "0.1.2-beta",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [
@@ -47,8 +48,8 @@
     "directory": "memori-ts"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.74.0",
-    "openai": "^4.0.0"
+    "@anthropic-ai/sdk": "*",
+    "openai": "*"
   },
   "peerDependenciesMeta": {
     "openai": {
@@ -59,7 +60,7 @@
     }
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.74.0",
+    "@anthropic-ai/sdk": "*",
     "@eslint/js": "^9.0.0",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^2.1.9",
@@ -68,7 +69,7 @@
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "lint-staged": "^15.0.0",
-    "openai": "^4.0.0",
+    "openai": "*",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
@@ -78,6 +79,6 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@memorilabs/axon": "^0.1.2-beta"
+    "@memorilabs/axon": "^0.1.3-beta"
   }
 }


### PR DESCRIPTION
Release bump to 0.1.2-beta for @memorilabs/memori. 

Update @memorilabs/axon dependency to ^0.1.3-beta, 

relax @anthropic-ai/sdk and openai peer/dev version constraints to wildcards, and add a default export mapping in package.json. package-lock updated to reflect these dependency changes.