### PR TITLE
Update publish workflow and package version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,6 +1,8 @@
 name: Publish to npm (TS)
 
 on:
+  release:
+    types: [published]
   workflow_dispatch: 
 
 permissions:
@@ -40,4 +42,4 @@ jobs:
         run: npm test --if-present
 
       - name: Publish Package
-        run: npm publish --access public --tag beta
+        run: npm publish --access public --tag latest

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.4-beta",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.1.4-beta",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.2"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.1.4-beta",
+  "version": "0.0.2",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Trigger the TS publish workflow on GitHub release 'published' and change npm publish tag from 'beta' to 'latest'. Bump @memorilabs/memori package version to 0.0.2 in package.json.