### PR TITLE
Add integrations API and Base OpenClaw support

### DIFF
--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memorilabs/memori",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@memorilabs/axon": "^0.1.2"

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memorilabs/memori",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The official TypeScript SDK for Memori",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./integrations": {
+      "import": "./dist/integrations/index.js",
+      "types": "./dist/integrations/index.d.ts"
     }
   },
   "files": [

--- a/memori-ts/src/integrations/base.ts
+++ b/memori-ts/src/integrations/base.ts
@@ -1,0 +1,80 @@
+import { LLMRequest, LLMResponse, CallContext } from '@memorilabs/axon';
+import { MemoriCore } from '../types/integrations.js';
+
+/**
+ * Abstract base class for Memori framework integrations.
+ *
+ * Provides common functionality for translating framework-specific data formats
+ * (like OpenClaw messages) into Axon's internal LLM request/response format.
+ *
+ * This class is internal to the SDK - framework integrations should extend it
+ * and implement their own public-facing methods.
+ *
+ * @internal
+ */
+export abstract class BaseIntegration {
+  constructor(protected readonly core: MemoriCore) {}
+
+  /**
+   * Internal helper: Captures a conversation turn by translating it into Axon format
+   * and feeding it to both the Persistence and Augmentation engines.
+   *
+   * @param userMessage - Raw user message text
+   * @param agentResponse - Raw agent response text
+   * @internal
+   */
+  protected async executeCapture(userMessage: string, agentResponse: string): Promise<void> {
+    if (!this.core.session.id) return;
+
+    const syntheticReq: LLMRequest = {
+      messages: [{ role: 'user', content: userMessage }],
+    };
+    const syntheticRes: LLMResponse = {
+      content: agentResponse,
+    };
+
+    const syntheticCtx: CallContext = {
+      traceId: `integration-trace-${Date.now()}`,
+      startedAt: new Date(),
+      metadata: {},
+    };
+
+    try {
+      await this.core.persistence.handlePersistence(syntheticReq, syntheticRes, syntheticCtx);
+      await this.core.augmentation.handleAugmentation(syntheticReq, syntheticRes, syntheticCtx);
+    } catch (e) {
+      console.warn('Memori Integration Capture failed:', e);
+    }
+  }
+
+  /**
+   * Internal helper: Recalls memories by translating the query into Axon format,
+   * passing it through the Recall engine, and extracting the injected system prompt.
+   *
+   * @param userMessage - Raw user query text
+   * @returns XML-formatted memory context, or undefined if no session or recall fails
+   * @internal
+   */
+  protected async executeRecall(userMessage: string): Promise<string | undefined> {
+    if (!this.core.session.id) return undefined;
+
+    const syntheticReq: LLMRequest = {
+      messages: [{ role: 'user', content: userMessage }],
+    };
+
+    const syntheticCtx: CallContext = {
+      traceId: `integration-trace-${Date.now()}`,
+      startedAt: new Date(),
+      metadata: {},
+    };
+
+    try {
+      const updatedReq = await this.core.recall.handleRecall(syntheticReq, syntheticCtx);
+      const systemMsg = updatedReq.messages.find((m) => m.role === 'system');
+      return systemMsg?.content;
+    } catch (e) {
+      console.warn('Memori Integration Recall failed:', e);
+      return undefined;
+    }
+  }
+}

--- a/memori-ts/src/integrations/index.ts
+++ b/memori-ts/src/integrations/index.ts
@@ -1,0 +1,1 @@
+export { OpenClawIntegration } from './openclaw.js';

--- a/memori-ts/src/integrations/openclaw.ts
+++ b/memori-ts/src/integrations/openclaw.ts
@@ -1,0 +1,56 @@
+import { BaseIntegration } from './base.js';
+
+/**
+ * OpenClaw-specific integration for Memori.
+ * Provides memory capture and recall functionality for OpenClaw agents.
+ */
+export class OpenClawIntegration extends BaseIntegration {
+  /**
+   * Sets the attribution context for memory operations.
+   *
+   * @param entityId - Unique identifier for the entity (required)
+   * @param processId - Optional identifier for the workflow/process/agent
+   * @returns This instance for method chaining
+   */
+  public setAttribution(entityId: string, processId?: string): this {
+    this.core.config.entityId = entityId;
+    if (processId) this.core.config.processId = processId;
+    return this;
+  }
+
+  /**
+   * Sets the current conversation session ID.
+   *
+   * @param sessionId - Unique session identifier
+   * @returns This instance for method chaining
+   */
+  public setSession(sessionId: string): this {
+    this.core.session.set(sessionId);
+    return this;
+  }
+
+  /**
+   * Captures a conversation turn and sends it to Memori for processing.
+   *
+   * @param userMessage - The user's input message
+   * @param agentResponse - The agent's complete response
+   * @returns Promise that resolves when capture is complete
+   *
+   * @throws Does not throw - errors are logged but swallowed to prevent disrupting the agent
+   */
+  public async capture(userMessage: string, agentResponse: string): Promise<void> {
+    await this.executeCapture(userMessage, agentResponse);
+  }
+
+  /**
+   * Retrieves relevant memories for the given prompt and returns formatted context.
+   *
+   * @param promptText - The user's prompt/query
+   * @returns Formatted XML context string to inject, or undefined if no relevant memories found
+   *
+   * @throws Does not throw - errors are logged but swallowed, returns undefined on failure
+   */
+  public async recall(promptText: string): Promise<string | undefined> {
+    return this.executeRecall(promptText);
+  }
+}

--- a/memori-ts/src/memori.ts
+++ b/memori-ts/src/memori.ts
@@ -6,6 +6,7 @@ import { RecallEngine } from './engines/recall.js';
 import { PersistenceEngine } from './engines/persistence.js';
 import { AugmentationEngine } from './engines/augmentation.js';
 import { ParsedFact } from './types/api.js';
+import { IntegrationConstructor, SupportedIntegration } from './types/integrations.js';
 
 /**
  * The main entry point for the Memori SDK.
@@ -119,5 +120,22 @@ export class Memori {
   public setSession(id: string): this {
     this.session.set(id);
     return this;
+  }
+
+  /**
+   * Securely attaches a supported framework integration to this Memori instance.
+   *
+   * @typeParam T - The type of integration being created
+   * @param IntegrationClass - The integration class constructor to instantiate
+   * @returns A new instance of the specified integration with access to Memori's core engines
+   */
+  public integrate<T extends SupportedIntegration>(IntegrationClass: IntegrationConstructor<T>): T {
+    return new IntegrationClass({
+      recall: this.recallEngine,
+      persistence: this.persistenceEngine,
+      augmentation: this.augmentationEngine,
+      config: this.config,
+      session: this.session,
+    });
   }
 }

--- a/memori-ts/src/types/integrations.ts
+++ b/memori-ts/src/types/integrations.ts
@@ -1,0 +1,18 @@
+import { Config } from '../core/config.js';
+import { SessionManager } from '../core/session.js';
+import { RecallEngine } from '../engines/recall.js';
+import { PersistenceEngine } from '../engines/persistence.js';
+import { AugmentationEngine } from '../engines/augmentation.js';
+import type { OpenClawIntegration } from '../integrations/openclaw.js';
+
+
+export interface MemoriCore {
+  recall: RecallEngine;
+  persistence: PersistenceEngine;
+  augmentation: AugmentationEngine;
+  config: Config;
+  session: SessionManager;
+}
+
+export type SupportedIntegration = OpenClawIntegration;
+export type IntegrationConstructor<T extends SupportedIntegration> = new (core: MemoriCore) => T;

--- a/memori-ts/tests/integrations/base.test.ts
+++ b/memori-ts/tests/integrations/base.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BaseIntegration } from '../../src/integrations/base.js';
+import { MemoriCore } from '../../src/types/integrations.js';
+import { LLMRequest } from '@memorilabs/axon';
+
+// Create a concrete implementation to test the protected methods of the abstract class
+class TestIntegration extends BaseIntegration {
+  public testCapture(userMessage: string, agentResponse: string) {
+    return this.executeCapture(userMessage, agentResponse);
+  }
+  public testRecall(userMessage: string) {
+    return this.executeRecall(userMessage);
+  }
+}
+
+describe('BaseIntegration', () => {
+  let mockCore: MemoriCore;
+  let integration: TestIntegration;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockCore = {
+      recall: { handleRecall: vi.fn() },
+      persistence: { handlePersistence: vi.fn() },
+      augmentation: { handleAugmentation: vi.fn() },
+      config: { entityId: 'test-user', processId: 'test-process' },
+      session: { id: 'test-session-id' },
+    } as unknown as MemoriCore;
+
+    integration = new TestIntegration(mockCore);
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('executeCapture()', () => {
+    it('should silently abort if no session ID is present', async () => {
+      (mockCore.session as any).id = undefined;
+
+      await integration.testCapture('user msg', 'ai msg');
+
+      expect(mockCore.persistence.handlePersistence).not.toHaveBeenCalled();
+      expect(mockCore.augmentation.handleAugmentation).not.toHaveBeenCalled();
+    });
+
+    it('should format requests and invoke persistence and augmentation engines', async () => {
+      await integration.testCapture('hello bot', 'hello human');
+
+      const expectedReq = expect.objectContaining({
+        messages: [{ role: 'user', content: 'hello bot' }],
+      });
+      const expectedRes = expect.objectContaining({
+        content: 'hello human',
+      });
+      const expectedCtx = expect.objectContaining({
+        traceId: expect.stringContaining('integration-trace-'),
+        metadata: {},
+      });
+
+      expect(mockCore.persistence.handlePersistence).toHaveBeenCalledWith(
+        expectedReq,
+        expectedRes,
+        expectedCtx
+      );
+      expect(mockCore.augmentation.handleAugmentation).toHaveBeenCalledWith(
+        expectedReq,
+        expectedRes,
+        expectedCtx
+      );
+    });
+
+    it('should swallow errors and log a warning if engines fail', async () => {
+      (mockCore.persistence.handlePersistence as any).mockRejectedValue(
+        new Error('Persistence failed')
+      );
+
+      // Should not throw
+      await expect(integration.testCapture('msg', 'resp')).resolves.toBeUndefined();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Memori Integration Capture failed:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('executeRecall()', () => {
+    it('should return undefined if no session ID is present', async () => {
+      (mockCore.session as any).id = undefined;
+
+      const result = await integration.testRecall('who am i?');
+
+      expect(result).toBeUndefined();
+      expect(mockCore.recall.handleRecall).not.toHaveBeenCalled();
+    });
+
+    it('should format the request, invoke the recall engine, and extract the system message', async () => {
+      const mockUpdatedReq: LLMRequest = {
+        messages: [
+          { role: 'system', content: '<memori_context>You like apples.</memori_context>' },
+          { role: 'user', content: 'what do I like?' },
+        ],
+      };
+      (mockCore.recall.handleRecall as any).mockResolvedValue(mockUpdatedReq);
+
+      const result = await integration.testRecall('what do I like?');
+
+      expect(mockCore.recall.handleRecall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [{ role: 'user', content: 'what do I like?' }],
+        }),
+        expect.objectContaining({
+          traceId: expect.stringContaining('integration-trace-'),
+          metadata: {},
+        })
+      );
+      expect(result).toBe('<memori_context>You like apples.</memori_context>');
+    });
+
+    it('should return undefined if the recall engine does not inject a system message', async () => {
+      const mockUpdatedReq: LLMRequest = {
+        messages: [{ role: 'user', content: 'what do I like?' }],
+      };
+      (mockCore.recall.handleRecall as any).mockResolvedValue(mockUpdatedReq);
+
+      const result = await integration.testRecall('what do I like?');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should swallow errors, log a warning, and return undefined on failure', async () => {
+      (mockCore.recall.handleRecall as any).mockRejectedValue(new Error('Recall failed'));
+
+      const result = await integration.testRecall('query');
+
+      expect(result).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Memori Integration Recall failed:',
+        expect.any(Error)
+      );
+    });
+  });
+});

--- a/memori-ts/tests/integrations/openclaw.test.ts
+++ b/memori-ts/tests/integrations/openclaw.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenClawIntegration } from '../../src/integrations/openclaw.js';
+import { MemoriCore } from '../../src/types/integrations.js';
+
+describe('OpenClawIntegration', () => {
+  let mockCore: MemoriCore;
+  let openclaw: OpenClawIntegration;
+
+  beforeEach(() => {
+    mockCore = {
+      recall: {} as any,
+      persistence: {} as any,
+      augmentation: {} as any,
+      config: { entityId: undefined, processId: undefined },
+      session: {
+        id: 'default-session-id',
+        set: vi.fn().mockReturnThis(),
+      },
+    } as unknown as MemoriCore;
+
+    openclaw = new OpenClawIntegration(mockCore);
+  });
+
+  describe('setAttribution()', () => {
+    it('should update entityId and return instance for chaining', () => {
+      const result = openclaw.setAttribution('user-123');
+
+      expect(mockCore.config.entityId).toBe('user-123');
+      expect(mockCore.config.processId).toBeUndefined();
+      expect(result).toBe(openclaw); // Chainable
+    });
+
+    it('should update both entityId and processId', () => {
+      openclaw.setAttribution('user-123', 'openclaw-agent');
+
+      expect(mockCore.config.entityId).toBe('user-123');
+      expect(mockCore.config.processId).toBe('openclaw-agent');
+    });
+  });
+
+  describe('setSession()', () => {
+    it('should delegate to core session manager and return instance for chaining', () => {
+      const result = openclaw.setSession('custom-session-uuid');
+
+      expect(mockCore.session.set).toHaveBeenCalledWith('custom-session-uuid');
+      expect(result).toBe(openclaw); // Chainable
+    });
+  });
+
+  describe('capture()', () => {
+    it('should delegate to the inherited executeCapture method', async () => {
+      // Spy on the protected method inherited from BaseIntegration
+      const executeCaptureSpy = vi
+        .spyOn(openclaw as any, 'executeCapture')
+        .mockResolvedValue(undefined);
+
+      await openclaw.capture('user says hi', 'bot says hello');
+
+      expect(executeCaptureSpy).toHaveBeenCalledWith('user says hi', 'bot says hello');
+    });
+  });
+
+  describe('recall()', () => {
+    it('should delegate to the inherited executeRecall method and return the result', async () => {
+      const mockMemoryContext = '<memori_context>context data</memori_context>';
+
+      // Spy on the protected method inherited from BaseIntegration
+      const executeRecallSpy = vi
+        .spyOn(openclaw as any, 'executeRecall')
+        .mockResolvedValue(mockMemoryContext);
+
+      const result = await openclaw.recall('prompt text');
+
+      expect(executeRecallSpy).toHaveBeenCalledWith('prompt text');
+      expect(result).toBe(mockMemoryContext);
+    });
+  });
+});


### PR DESCRIPTION
- Introduce a framework for integrations
   - Add an abstract `BaseIntegration` with executeCapture/executeRecall helpers
   - Add `OpenClawIntegration` implementation (setAttribution, setSession, capture, recall)
   - Add types for `MemoriCore` and IntegrationConstructor 
   - Expose a new `Memori.integrate<T>()` method to instantiate integrations with access to core engines
 
- Export the integrations entry in package.json
- Add unit tests for the base integration and OpenClaw integration
- Bump package version to 0.0.3.