### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/memori/llm/_clients.py
+++ b/memori/llm/_clients.py
@@ -498,6 +498,8 @@ def _detect_platform(client):
             return "deepseek"
         elif "nvidia" in base_url:
             return "nvidia_nim"
+        elif "minimax" in base_url:
+            return "minimax"
     return None
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY")
 XAI_API_KEY = os.environ.get("XAI_API_KEY")
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY")
 
 requires_openai = pytest.mark.skipif(
     not OPENAI_API_KEY,
@@ -38,6 +39,11 @@ requires_google = pytest.mark.skipif(
 requires_xai = pytest.mark.skipif(
     not XAI_API_KEY,
     reason="XAI_API_KEY environment variable not set",
+)
+
+requires_minimax = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason="MINIMAX_API_KEY environment variable not set",
 )
 
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
@@ -237,6 +243,47 @@ def registered_async_xai_client(memori_instance, async_xai_client):
     memori_instance.llm.register(async_xai_client)
     memori_instance.attribution(entity_id="test-entity", process_id="test-process")
     return async_xai_client
+
+
+@pytest.fixture(scope="session")
+def minimax_api_key():
+    if not MINIMAX_API_KEY:
+        pytest.skip("MINIMAX_API_KEY not set")
+    return MINIMAX_API_KEY
+
+
+@pytest.fixture
+def minimax_client(minimax_api_key):
+    from openai import OpenAI
+
+    return OpenAI(
+        api_key=minimax_api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+
+@pytest.fixture
+def async_minimax_client(minimax_api_key):
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(
+        api_key=minimax_api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+
+@pytest.fixture
+def registered_minimax_client(memori_instance, minimax_client):
+    memori_instance.llm.register(minimax_client)
+    memori_instance.attribution(entity_id="test-entity", process_id="test-process")
+    return minimax_client
+
+
+@pytest.fixture
+def registered_async_minimax_client(memori_instance, async_minimax_client):
+    memori_instance.llm.register(async_minimax_client)
+    memori_instance.attribution(entity_id="test-entity", process_id="test-process")
+    return async_minimax_client
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/providers/test_minimax.py
+++ b/tests/integration/providers/test_minimax.py
@@ -1,0 +1,409 @@
+import pytest
+from openai import (
+    AsyncOpenAI,
+    OpenAI,
+)
+
+from tests.integration.conftest import requires_minimax
+
+MODEL = "MiniMax-M2.5"
+MODEL_HIGHSPEED = "MiniMax-M2.5-highspeed"
+MAX_TOKENS = 50
+TEST_PROMPT = "Say 'hello' in one word."
+
+
+class TestClientRegistration:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_client_registration_marks_installed(
+        self, memori_instance, minimax_api_key
+    ):
+        client = OpenAI(
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+
+        assert not hasattr(client, "_memori_installed")
+
+        memori_instance.llm.register(client)
+
+        assert hasattr(client, "_memori_installed")
+        assert getattr(client, "_memori_installed", False) is True
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_async_client_registration_marks_installed(
+        self, memori_instance, minimax_api_key
+    ):
+        client = AsyncOpenAI(
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+
+        assert not hasattr(client, "_memori_installed")
+
+        memori_instance.llm.register(client)
+
+        assert hasattr(client, "_memori_installed")
+        assert getattr(client, "_memori_installed", False) is True
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_platform_detected_as_minimax(self, memori_instance, minimax_api_key):
+        client = OpenAI(
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+        memori_instance.llm.register(client)
+
+        assert memori_instance.config.platform.provider == "minimax"
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_multiple_registrations_are_idempotent(
+        self, memori_instance, minimax_api_key
+    ):
+        client = OpenAI(
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+
+        memori_instance.llm.register(client)
+        original_create = client.chat.completions.create
+
+        memori_instance.llm.register(client)
+
+        assert client.chat.completions.create is original_create
+        assert getattr(client, "_memori_installed", False) is True
+
+
+class TestSyncChatCompletions:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_chat_completion_returns_response(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response is not None
+        assert hasattr(response, "choices")
+        assert len(response.choices) > 0
+        assert response.choices[0].message.content is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_chat_completion_response_structure(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert hasattr(response, "id")
+        assert hasattr(response, "model")
+        assert hasattr(response, "choices")
+        assert hasattr(response, "usage")
+
+        choice = response.choices[0]
+        assert hasattr(choice, "message")
+        assert hasattr(choice, "finish_reason")
+        assert hasattr(choice.message, "role")
+        assert hasattr(choice.message, "content")
+        assert choice.message.role == "assistant"
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_chat_completion_with_system_message(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": TEST_PROMPT},
+            ],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response is not None
+        assert response.choices[0].message.content is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_chat_completion_with_highspeed_model(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL_HIGHSPEED,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response is not None
+        assert hasattr(response, "choices")
+        assert len(response.choices) > 0
+        assert response.choices[0].message.content is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_chat_completion_multi_turn(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[
+                {"role": "user", "content": "My name is Alice."},
+                {"role": "assistant", "content": "Nice to meet you, Alice!"},
+                {"role": "user", "content": "What is my name?"},
+            ],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response is not None
+        content = response.choices[0].message.content.lower()
+        assert "alice" in content
+
+
+class TestAsyncChatCompletions:
+    @requires_minimax
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_async_chat_completion_returns_response(
+        self, registered_async_minimax_client
+    ):
+        response = await registered_async_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response is not None
+        assert hasattr(response, "choices")
+        assert len(response.choices) > 0
+        assert response.choices[0].message.content is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_async_chat_completion_response_structure(
+        self, registered_async_minimax_client
+    ):
+        response = await registered_async_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert hasattr(response, "id")
+        assert hasattr(response, "model")
+        assert hasattr(response, "choices")
+        assert hasattr(response, "usage")
+
+        choice = response.choices[0]
+        assert hasattr(choice, "message")
+        assert choice.message.role == "assistant"
+
+
+class TestSyncStreaming:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_streaming_returns_chunks(self, registered_minimax_client):
+        stream = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+            stream=True,
+        )
+
+        chunks = list(stream)
+
+        assert len(chunks) > 0
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_sync_streaming_assembles_content(self, registered_minimax_client):
+        stream = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+            stream=True,
+        )
+
+        content_parts = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                content_parts.append(chunk.choices[0].delta.content)
+
+        full_content = "".join(content_parts)
+        assert len(full_content) > 0
+
+
+class TestAsyncStreaming:
+    @requires_minimax
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_async_streaming_returns_chunks(self, registered_async_minimax_client):
+        stream = await registered_async_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+            stream=True,
+        )
+
+        chunks = []
+        async for chunk in stream:
+            chunks.append(chunk)
+
+        assert len(chunks) > 0
+
+    @requires_minimax
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_async_streaming_assembles_content(
+        self, registered_async_minimax_client
+    ):
+        stream = await registered_async_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+            stream=True,
+        )
+
+        content_parts = []
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                content_parts.append(chunk.choices[0].delta.content)
+
+        full_content = "".join(content_parts)
+        assert len(full_content) > 0
+
+
+class TestResponseFormatValidation:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_response_contains_usage_metadata(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert response.usage is not None
+        assert response.usage.prompt_tokens > 0
+        assert response.usage.completion_tokens > 0
+        assert response.usage.total_tokens > 0
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_response_finish_reason_is_valid(self, registered_minimax_client):
+        response = registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        valid_reasons = {
+            "stop",
+            "length",
+            "content_filter",
+            "tool_calls",
+            "function_call",
+        }
+        assert response.choices[0].finish_reason in valid_reasons
+
+
+class TestMemoriIntegration:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_config_captures_provider_info(self, memori_instance, minimax_api_key):
+        client = OpenAI(
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        )
+        memori_instance.llm.register(client)
+
+        assert memori_instance.config.llm.provider_sdk_version is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_attribution_is_preserved_across_calls(
+        self, registered_minimax_client, memori_instance
+    ):
+        memori_instance.attribution(entity_id="user-123", process_id="process-456")
+
+        registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        assert memori_instance.config.entity_id == "user-123"
+        assert memori_instance.config.process_id == "process-456"
+
+
+class TestStorageVerification:
+    @requires_minimax
+    @pytest.mark.integration
+    def test_conversation_stored_after_sync_call(
+        self, registered_minimax_client, memori_instance
+    ):
+        registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        conversation_id = memori_instance.config.cache.conversation_id
+        assert conversation_id is not None
+
+        conversation = memori_instance.config.storage.driver.conversation.read(
+            conversation_id
+        )
+        assert conversation is not None
+        assert conversation["id"] == conversation_id
+
+    @requires_minimax
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_conversation_stored_after_async_call(
+        self, registered_async_minimax_client, memori_instance
+    ):
+        await registered_async_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": TEST_PROMPT}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        conversation_id = memori_instance.config.cache.conversation_id
+        assert conversation_id is not None
+
+        conversation = memori_instance.config.storage.driver.conversation.read(
+            conversation_id
+        )
+        assert conversation is not None
+
+    @requires_minimax
+    @pytest.mark.integration
+    def test_messages_stored_with_content(
+        self, registered_minimax_client, memori_instance
+    ):
+        test_query = "What is 2 + 2?"
+
+        registered_minimax_client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": test_query}],
+            max_tokens=MAX_TOKENS,
+        )
+
+        conversation_id = memori_instance.config.cache.conversation_id
+        assert conversation_id is not None
+
+        messages = memori_instance.config.storage.driver.conversation.messages.read(
+            conversation_id
+        )
+
+        assert len(messages) >= 2
+
+        user_messages = [m for m in messages if m["role"] == "user"]
+        assert len(user_messages) >= 1
+        assert test_query in user_messages[0]["content"]
+
+        assistant_messages = [m for m in messages if m["role"] == "assistant"]
+        assert len(assistant_messages) >= 1
+        assert len(assistant_messages[0]["content"]) > 0

--- a/tests/llm/providers/minimax/test_minimax.py
+++ b/tests/llm/providers/minimax/test_minimax.py
@@ -1,0 +1,199 @@
+"""
+Tests for MiniMax client detection and registration.
+
+MiniMax provides an OpenAI-compatible API, so clients are created using
+the OpenAI SDK with a custom base_url pointing to api.minimax.io.
+Memori detects MiniMax as a platform via _detect_platform().
+"""
+
+import pytest
+
+from memori._config import Config
+from memori.llm._clients import OpenAi, _detect_platform
+
+
+@pytest.fixture
+def config():
+    return Config()
+
+
+@pytest.fixture
+def openai_handler(config):
+    return OpenAi(config)
+
+
+class TestMiniMaxPlatformDetection:
+    """Tests for MiniMax platform detection via base_url."""
+
+    def test_detect_minimax_io_base_url(self):
+        """MiniMax international API should be detected."""
+
+        class FakeClient:
+            base_url = "https://api.minimax.io/v1"
+
+        assert _detect_platform(FakeClient()) == "minimax"
+
+    def test_detect_minimaxi_com_base_url(self):
+        """MiniMax China API should be detected."""
+
+        class FakeClient:
+            base_url = "https://api.minimaxi.com/v1"
+
+        assert _detect_platform(FakeClient()) == "minimax"
+
+    def test_detect_minimax_case_insensitive(self):
+        """Detection should be case-insensitive."""
+
+        class FakeClient:
+            base_url = "https://api.MiniMax.io/v1"
+
+        assert _detect_platform(FakeClient()) == "minimax"
+
+    def test_no_base_url_returns_none(self):
+        """Client without base_url should return None."""
+
+        class FakeClient:
+            pass
+
+        assert _detect_platform(FakeClient()) is None
+
+    def test_openai_base_url_not_detected_as_minimax(self):
+        """OpenAI base_url should not be detected as MiniMax."""
+
+        class FakeClient:
+            base_url = "https://api.openai.com/v1"
+
+        assert _detect_platform(FakeClient()) != "minimax"
+
+    def test_other_platforms_not_detected_as_minimax(self):
+        """Other platform URLs should not be detected as MiniMax."""
+        urls = [
+            "https://api.deepseek.com/v1",
+            "https://api.x.ai/v1",
+            "https://integrate.api.nvidia.com/v1",
+        ]
+        for url in urls:
+
+            class FakeClient:
+                base_url = url
+
+            result = _detect_platform(FakeClient())
+            assert result != "minimax", f"URL {url} should not be detected as minimax"
+
+
+class TestMiniMaxClientRegistration:
+    """Tests for MiniMax client registration with Memori using OpenAI handler."""
+
+    def test_openai_handler_registers_minimax_client(self, openai_handler, mocker):
+        """Verify OpenAi handler can register MiniMax-configured clients."""
+        mock_client = mocker.MagicMock()
+        mock_client._version = "1.0.0"
+        mock_client.chat.completions.create = mocker.MagicMock()
+        mock_client.beta.chat.completions.parse = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        result = openai_handler.register(mock_client)
+
+        assert result is openai_handler
+        assert hasattr(mock_client, "_memori_installed")
+        assert mock_client._memori_installed is True
+
+    def test_minimax_platform_set_after_registration(self, openai_handler, config, mocker):
+        """Verify platform is set to 'minimax' after client registration."""
+        mock_client = mocker.MagicMock()
+        mock_client._version = "1.0.0"
+        mock_client.chat.completions.create = mocker.MagicMock()
+        mock_client.beta.chat.completions.parse = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        openai_handler.register(mock_client)
+
+        assert config.platform.provider == "minimax"
+
+    def test_minimax_handler_wraps_chat_completions_create(
+        self, openai_handler, mocker
+    ):
+        """Verify handler wraps chat.completions.create for MiniMax."""
+        mock_client = mocker.MagicMock()
+        mock_client._version = "1.0.0"
+        mock_client.beta.chat.completions.parse = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        openai_handler.register(mock_client)
+
+        assert hasattr(mock_client.chat, "_completions_create")
+
+    def test_minimax_handler_wraps_beta_parse(self, openai_handler, mocker):
+        """Verify handler wraps beta.chat.completions.parse for MiniMax."""
+        mock_client = mocker.MagicMock()
+        mock_client._version = "1.0.0"
+        mock_client.chat.completions.create = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        openai_handler.register(mock_client)
+
+        assert hasattr(mock_client.beta, "_chat_completions_parse")
+
+    def test_minimax_registration_is_idempotent(self, openai_handler, mocker):
+        """Verify multiple registrations don't re-wrap methods."""
+        mock_client = mocker.MagicMock()
+        mock_client._version = "1.0.0"
+        mock_client.chat.completions.create = mocker.MagicMock()
+        mock_client.beta.chat.completions.parse = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        openai_handler.register(mock_client)
+        original_create = mock_client.chat.completions.create
+
+        openai_handler.register(mock_client)
+
+        assert mock_client.chat.completions.create == original_create
+        assert mock_client._memori_installed is True
+
+
+class TestMiniMaxAutoRegistration:
+    """Tests for MiniMax auto-detection via llm.register()."""
+
+    def test_llm_register_auto_detects_minimax_client(self, mocker):
+        """Test that llm.register() auto-detects MiniMax client (OpenAI with minimax base_url)."""
+        from memori import Memori
+
+        mock_conn = mocker.MagicMock()
+        mocker.patch("memori.storage.Manager.start", return_value=mocker.MagicMock())
+        mocker.patch(
+            "memori.memory.augmentation.Manager.start",
+            return_value=mocker.MagicMock(),
+        )
+        memori_instance = Memori(conn=mock_conn)
+
+        mock_client = mocker.MagicMock()
+        type(mock_client).__module__ = "openai"
+        mock_client._version = "2.8.1"
+        mock_client.chat.completions.create = mocker.MagicMock()
+        mock_client.beta.chat.completions.parse = mocker.MagicMock()
+        mock_client.base_url = "https://api.minimax.io/v1"
+        del mock_client._memori_installed
+
+        mocker.patch("asyncio.get_running_loop", side_effect=RuntimeError)
+
+        result = memori_instance.llm.register(mock_client)
+
+        assert result is memori_instance
+        assert hasattr(mock_client, "_memori_installed")
+        assert mock_client._memori_installed is True
+        assert memori_instance.config.platform.provider == "minimax"


### PR DESCRIPTION
## Summary
- Add MiniMax as a new platform provider for Memori via OpenAI-compatible API detection
- Support both `api.minimax.io` (international) and `api.minimaxi.com` base URLs
- Add comprehensive unit and integration tests for MiniMax provider

## Supported Models
| Model | Description |
|-------|-------------|
| `MiniMax-M2.5` | Peak Performance. Ultimate Value. Master the Complex (204,800 token context) |
| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile (204,800 token context) |

## Changes
- **`memori/llm/_clients.py`**: Add `minimax` platform detection in `_detect_platform()` — when an OpenAI client's `base_url` contains "minimax", the platform is identified as MiniMax
- **`tests/integration/conftest.py`**: Add `MINIMAX_API_KEY` env var, `requires_minimax` skip marker, and MiniMax client fixtures (sync/async, registered/unregistered)
- **`tests/integration/providers/test_minimax.py`**: Full integration test suite covering client registration, sync/async chat completions, streaming, multi-turn conversations, response validation, and storage verification
- **`tests/llm/providers/minimax/test_minimax.py`**: Unit tests for platform detection (`_detect_platform`), client registration, platform config, and auto-detection via `llm.register()`

## Usage Example
```python
from openai import OpenAI
from memori import Memori

client = OpenAI(
    api_key="your-minimax-api-key",
    base_url="https://api.minimax.io/v1",
)

mem = Memori()
mem.llm.register(client)

response = client.chat.completions.create(
    model="MiniMax-M2.5",
    messages=[{"role": "user", "content": "Hello!"}],
)
```

## Test Results
All 12 new unit tests pass. All 265 existing tests continue to pass unchanged.

## API Documentation
- [OpenAI Compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api)
- [Anthropic Compatible API](https://platform.minimax.io/docs/api-reference/text-anthropic-api)