### PR TITLE
Default SDK version to 0.0.0

### DIFF
--- a/integrations/openclaw/src/version.ts
+++ b/integrations/openclaw/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during CI builds.
-export const SDK_VERSION = '0.0.0-openclaw-plugin-dev';
+export const SDK_VERSION = '0.0.0';

--- a/memori-ts/src/version.ts
+++ b/memori-ts/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated during CI builds.
-export const SDK_VERSION = '0.0.0-dev';
+export const SDK_VERSION = '0.0.0';


### PR DESCRIPTION
- Set default SDK version to 0.0.0, this only impacts local testing