### PR TITLE
feat: add MongoDB driver handshake metadata (DriverInfo)

### DIFF
--- a/memori/storage/adapters/mongodb/_adapter.py
+++ b/memori/storage/adapters/mongodb/_adapter.py
@@ -8,10 +8,15 @@ r"""
                        memorilabs.ai
 """
 
+from importlib.metadata import version as get_version
+
+from pymongo.driver_info import DriverInfo
 from pymongo.synchronous.mongo_client import MongoClient
 
 from memori.storage._base import BaseStorageAdapter
 from memori.storage._registry import Registry
+
+_DRIVER_INFO = DriverInfo(name="Memori", version=get_version("memori"))
 
 
 @Registry.register_adapter(
@@ -19,6 +24,12 @@ from memori.storage._registry import Registry
 )
 class Adapter(BaseStorageAdapter):
     """MongoDB storage adapter for MongoDB database connections."""
+
+    def __init__(self, conn):
+        super().__init__(conn)
+        client = self.conn if isinstance(self.conn, MongoClient) else getattr(self.conn, "client", None)
+        if hasattr(client, "append_metadata"):
+            client.append_metadata(_DRIVER_INFO)
 
     def execute(self, collection_name_or_ops, operation=None, *args, **kwargs):
         """Execute MongoDB operations.

--- a/memori/storage/adapters/mongodb/_adapter.py
+++ b/memori/storage/adapters/mongodb/_adapter.py
@@ -27,7 +27,11 @@ class Adapter(BaseStorageAdapter):
 
     def __init__(self, conn):
         super().__init__(conn)
-        client = self.conn if isinstance(self.conn, MongoClient) else getattr(self.conn, "client", None)
+        client = (
+            self.conn
+            if isinstance(self.conn, MongoClient)
+            else getattr(self.conn, "client", None)
+        )
         if hasattr(client, "append_metadata"):
             client.append_metadata(_DRIVER_INFO)
 

--- a/tests/storage/adapters/mongodb/test_mongodb_adapter.py
+++ b/tests/storage/adapters/mongodb/test_mongodb_adapter.py
@@ -60,3 +60,38 @@ def test_append_metadata_includes_version(mocker, mock_mongo_db):
     call_arg = mock_mongo_db.client.append_metadata.call_args[0][0]
     assert call_arg.version is not None
     assert call_arg.version != ""
+
+
+def test_execute(mongodb_conn):
+    """Test MongoDB adapter execute method."""
+    adapter = Adapter(lambda: mongodb_conn)
+
+    adapter.execute("test_collection", "find_one", {"test": "value"})
+    adapter.execute("test_collection", "insert_one", {"test": "value"})
+
+
+def test_get_dialect(mongodb_conn):
+    """Test MongoDB adapter get_dialect method."""
+    adapter = Adapter(lambda: mongodb_conn)
+    assert adapter.get_dialect() == "mongodb"
+
+
+def test_execute_with_args(mongodb_conn):
+    """Test MongoDB adapter execute method with various arguments."""
+    adapter = Adapter(lambda: mongodb_conn)
+
+    adapter.execute("test_collection", "find", {"test": "value"}, {"field": 1, "_id": 0})
+    adapter.execute("test_collection", "delete_many", {"test": "value"})
+
+
+def test_execute_with_kwargs(mongodb_conn):
+    """Test MongoDB adapter execute method with keyword arguments."""
+    adapter = Adapter(lambda: mongodb_conn)
+
+    adapter.execute(
+        "test_collection",
+        "update_one",
+        {"test": "value"},
+        {"$set": {"updated": True}},
+        upsert=True,
+    )

--- a/tests/storage/adapters/mongodb/test_mongodb_adapter.py
+++ b/tests/storage/adapters/mongodb/test_mongodb_adapter.py
@@ -33,7 +33,7 @@ def mock_mongo_db(mocker):
 
 def test_append_metadata_called_when_conn_is_mongo_client(mocker, mock_mongo_client):
     """Adapter calls append_metadata on a MongoClient passed directly."""
-    adapter = Adapter(lambda: mock_mongo_client)
+    Adapter(lambda: mock_mongo_client)
     mock_mongo_client.append_metadata.assert_called_once()
     call_arg = mock_mongo_client.append_metadata.call_args[0][0]
     assert call_arg.name == "Memori"
@@ -41,7 +41,7 @@ def test_append_metadata_called_when_conn_is_mongo_client(mocker, mock_mongo_cli
 
 def test_append_metadata_called_when_conn_is_database(mocker, mock_mongo_db):
     """Adapter calls append_metadata on client retrieved from a database object."""
-    adapter = Adapter(lambda: mock_mongo_db)
+    Adapter(lambda: mock_mongo_db)
     mock_mongo_db.client.append_metadata.assert_called_once()
     call_arg = mock_mongo_db.client.append_metadata.call_args[0][0]
     assert call_arg.name == "Memori"
@@ -51,12 +51,12 @@ def test_append_metadata_skipped_when_not_available(mocker, mock_mongo_db):
     """Adapter does not raise if append_metadata is absent (older PyMongo)."""
     del mock_mongo_db.client.append_metadata
     # Should not raise
-    adapter = Adapter(lambda: mock_mongo_db)
+    Adapter(lambda: mock_mongo_db)
 
 
 def test_append_metadata_includes_version(mocker, mock_mongo_db):
     """DriverInfo passed to append_metadata carries a non-empty version string."""
-    adapter = Adapter(lambda: mock_mongo_db)
+    Adapter(lambda: mock_mongo_db)
     call_arg = mock_mongo_db.client.append_metadata.call_args[0][0]
     assert call_arg.version is not None
     assert call_arg.version != ""

--- a/tests/storage/adapters/mongodb/test_mongodb_adapter.py
+++ b/tests/storage/adapters/mongodb/test_mongodb_adapter.py
@@ -12,6 +12,7 @@ def mock_mongo_client(mocker):
     client.get_default_database = mocker.MagicMock(return_value=mocker.MagicMock())
     # Make isinstance(client, MongoClient) work by patching the class
     from pymongo.synchronous.mongo_client import MongoClient
+
     mocker.patch(
         "memori.storage.adapters.mongodb._adapter.MongoClient",
         MongoClient,
@@ -80,7 +81,9 @@ def test_execute_with_args(mongodb_conn):
     """Test MongoDB adapter execute method with various arguments."""
     adapter = Adapter(lambda: mongodb_conn)
 
-    adapter.execute("test_collection", "find", {"test": "value"}, {"field": 1, "_id": 0})
+    adapter.execute(
+        "test_collection", "find", {"test": "value"}, {"field": 1, "_id": 0}
+    )
     adapter.execute("test_collection", "delete_many", {"test": "value"})
 
 

--- a/tests/storage/adapters/mongodb/test_mongodb_adapter.py
+++ b/tests/storage/adapters/mongodb/test_mongodb_adapter.py
@@ -1,0 +1,62 @@
+import pytest
+
+from memori.storage.adapters.mongodb._adapter import Adapter
+
+
+@pytest.fixture
+def mock_mongo_client(mocker):
+    """MongoClient instance passed directly as conn."""
+    client = mocker.MagicMock()
+    client.list_collection_names = mocker.MagicMock(return_value=[])
+    client.database = mocker.MagicMock()
+    client.get_default_database = mocker.MagicMock(return_value=mocker.MagicMock())
+    # Make isinstance(client, MongoClient) work by patching the class
+    from pymongo.synchronous.mongo_client import MongoClient
+    mocker.patch(
+        "memori.storage.adapters.mongodb._adapter.MongoClient",
+        MongoClient,
+    )
+    client.__class__ = MongoClient
+    return client
+
+
+@pytest.fixture
+def mock_mongo_db(mocker):
+    """IMongoDatabase-style object with a .client attribute."""
+    db = mocker.MagicMock()
+    db.list_collection_names = mocker.MagicMock(return_value=[])
+    db.database = mocker.MagicMock()
+    client = mocker.MagicMock()
+    db.client = client
+    return db
+
+
+def test_append_metadata_called_when_conn_is_mongo_client(mocker, mock_mongo_client):
+    """Adapter calls append_metadata on a MongoClient passed directly."""
+    adapter = Adapter(lambda: mock_mongo_client)
+    mock_mongo_client.append_metadata.assert_called_once()
+    call_arg = mock_mongo_client.append_metadata.call_args[0][0]
+    assert call_arg.name == "Memori"
+
+
+def test_append_metadata_called_when_conn_is_database(mocker, mock_mongo_db):
+    """Adapter calls append_metadata on client retrieved from a database object."""
+    adapter = Adapter(lambda: mock_mongo_db)
+    mock_mongo_db.client.append_metadata.assert_called_once()
+    call_arg = mock_mongo_db.client.append_metadata.call_args[0][0]
+    assert call_arg.name == "Memori"
+
+
+def test_append_metadata_skipped_when_not_available(mocker, mock_mongo_db):
+    """Adapter does not raise if append_metadata is absent (older PyMongo)."""
+    del mock_mongo_db.client.append_metadata
+    # Should not raise
+    adapter = Adapter(lambda: mock_mongo_db)
+
+
+def test_append_metadata_includes_version(mocker, mock_mongo_db):
+    """DriverInfo passed to append_metadata carries a non-empty version string."""
+    adapter = Adapter(lambda: mock_mongo_db)
+    call_arg = mock_mongo_db.client.append_metadata.call_args[0][0]
+    assert call_arg.version is not None
+    assert call_arg.version != ""

--- a/tests/storage/adapters/sqlalchemy/test_storage_adaptors_sqlalchemy_adapter.py
+++ b/tests/storage/adapters/sqlalchemy/test_storage_adaptors_sqlalchemy_adapter.py
@@ -67,4 +67,3 @@ def test_get_dialect_postgres(postgres_session):
 def test_rollback_postgres(postgres_session):
     adapter = SqlAlchemyAdapter(lambda: postgres_session)
     adapter.rollback()
-

--- a/tests/storage/adapters/sqlalchemy/test_storage_adaptors_sqlalchemy_adapter.py
+++ b/tests/storage/adapters/sqlalchemy/test_storage_adaptors_sqlalchemy_adapter.py
@@ -1,4 +1,3 @@
-from memori.storage.adapters.mongodb._adapter import Adapter as MongoAdapter
 from memori.storage.adapters.sqlalchemy._adapter import Adapter as SqlAlchemyAdapter
 
 
@@ -69,49 +68,3 @@ def test_rollback_postgres(postgres_session):
     adapter = SqlAlchemyAdapter(lambda: postgres_session)
     adapter.rollback()
 
-
-# MongoDB tests
-def test_mongodb_adapter_execute(mongodb_conn):
-    """Test MongoDB adapter execute method."""
-    adapter = MongoAdapter(lambda: mongodb_conn)
-
-    # Test find_one operation
-    adapter.execute("test_collection", "find_one", {"test": "value"})
-    # The mock should return the mocked result
-
-    # Test insert_one operation
-    adapter.execute("test_collection", "insert_one", {"test": "value"})
-    # The mock should return the mocked result
-
-
-def test_mongodb_adapter_get_dialect(mongodb_conn):
-    """Test MongoDB adapter get_dialect method."""
-    adapter = MongoAdapter(lambda: mongodb_conn)
-    assert adapter.get_dialect() == "mongodb"
-
-
-def test_mongodb_adapter_execute_with_args(mongodb_conn):
-    """Test MongoDB adapter execute method with various arguments."""
-    adapter = MongoAdapter(lambda: mongodb_conn)
-
-    # Test find operation with projection
-    adapter.execute(
-        "test_collection", "find", {"test": "value"}, {"field": 1, "_id": 0}
-    )
-
-    # Test delete_many operation
-    adapter.execute("test_collection", "delete_many", {"test": "value"})
-
-
-def test_mongodb_adapter_execute_with_kwargs(mongodb_conn):
-    """Test MongoDB adapter execute method with keyword arguments."""
-    adapter = MongoAdapter(lambda: mongodb_conn)
-
-    # Test update_one with upsert
-    adapter.execute(
-        "test_collection",
-        "update_one",
-        {"test": "value"},
-        {"$set": {"updated": True}},
-        upsert=True,
-    )


### PR DESCRIPTION
Sets [`pymongo.driver_info.DriverInfo`](https://pymongo.readthedocs.io/en/stable/api/pymongo/driver_info.html#pymongo.driver_info.DriverInfo) on every `MongoClient` passed to the MongoDB storage adapter, so MongoDB server-side telemetry attributes traffic to Memori rather than showing it as a generic driver connection (per MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification)

For example:

> {"t":{"$date":"2024-06-03T16:10:26.686-04:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn225","msg":"client metadata","attr":{"remote":"127.0.0.1:61857","client":"conn225","negotiatedCompressors":[],"doc":{"driver":{"name":"PyMongo|Memori","version":"3.11.4|x.y.z"},"os":{"type":"Darwin","name":"Darwin","architecture":"x86_64","version":"14.5"},"platform":"CPython 3.10.3.final.0"}}}

Note this PR also moves the MongoDB tests from the SqlAlchemy adapter's tests