### PR TITLE
Update embedding configurations to suppress progress output

### DIFF
--- a/core/src/embeddings/models.rs
+++ b/core/src/embeddings/models.rs
@@ -89,7 +89,7 @@ impl SentenceTransformersEmbedder {
         if model_guard.is_none() {
             let model = TextEmbedding::try_new(
                 TextInitOptions::new(self.embedding_model.clone())
-                    .with_show_download_progress(true)
+                    .with_show_download_progress(false)
                     .with_cache_dir(self.cache_dir.clone()),
             )?;
             *model_guard = Some(model);

--- a/memori/embeddings/_sentence_transformers.py
+++ b/memori/embeddings/_sentence_transformers.py
@@ -16,6 +16,7 @@ import threading
 from typing import Any
 
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("HF_HUB_VERBOSITY", "error")
 
 import numpy as np
 from huggingface_hub.utils import disable_progress_bars
@@ -30,6 +31,8 @@ logger = logging.getLogger(__name__)
 def _configure_huggingface_logging() -> None:
     # Suppress noisy model-loading warnings and progress output.
     transformers_logging.set_verbosity_error()
+    transformers_logging.disable_progress_bar()
+    logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
     disable_progress_bars()
 
 


### PR DESCRIPTION
- Set `with_show_download_progress` to false in Rust's SentenceTransformersEmbedder.
- Configure Hugging Face logging to suppress progress bars and set verbosity to error in Python's _sentence_transformers.py.