### PR TITLE
Grant contents write and set GITHUB_TOKEN env

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -164,6 +164,8 @@ jobs:
 
       - name: Create platform-specific npm packages
         working-directory: ./core/bindings/node
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx napi prepublish -t npm
 
       - name: Publish platform packages


### PR DESCRIPTION
Change workflow permissions for contents from read to write and export GITHUB_TOKEN to the napi prepublish step. This ensures the platform-specific npm package creation step can authenticate and modify release artifacts during the publish job.