### PR TITLE
Refactor publish workflow and update package management

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -132,72 +132,9 @@ jobs:
         working-directory: ./memori-ts
         run: npm test --if-present
 
-  publish-native:
-    name: Publish platform packages
-    needs: [build-native, build-and-test]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Download all native artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: native-*
-          path: native-downloads
-          merge-multiple: false
-
-      - name: Install NAPI CLI
-        working-directory: ./core/bindings/node
-        run: npm install
-
-      - name: Create platform package scaffolding
-        working-directory: ./core/bindings/node
-        run: npx napi create-npm-dir -t .
-
-      - name: Copy .node files into platform package folders
-        shell: bash
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          artifacts=(native-downloads/*/*.node)
-          if [ "${#artifacts[@]}" -eq 0 ]; then
-            echo "No native artifacts were downloaded."
-            exit 1
-          fi
-
-          for artifact in "${artifacts[@]}"; do
-            filename="$(basename "$artifact")"
-            target="${filename#memori_node.}"
-            target="${target%.node}"
-            destination="core/bindings/node/npm/${target}/${filename}"
-
-            if [ ! -d "core/bindings/node/npm/${target}" ]; then
-              echo "Missing target package directory for ${target}"
-              exit 1
-            fi
-
-            cp "$artifact" "$destination"
-          done
-
-      - name: Publish platform packages
-        working-directory: ./core/bindings/node
-        shell: bash
-        run: |
-          for dir in npm/*/; do
-            npm publish "$dir" --access public --tag beta
-          done
-
   publish:
     name: Publish @memorilabs/memori
-    needs: [publish-native]
+    needs: [build-native, build-and-test]
     runs-on: ubuntu-latest
 
     steps:
@@ -223,6 +160,28 @@ jobs:
         working-directory: ./core/bindings/node
         run: npm install
 
+      - name: Download all native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          path: native-downloads
+          merge-multiple: false
+
+      - name: Copy native artifacts into bindings directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          artifacts=(native-downloads/*/*.node)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No native artifacts were downloaded."
+            exit 1
+          fi
+
+          for artifact in "${artifacts[@]}"; do
+            cp "$artifact" core/bindings/node/
+          done
+
       - name: Install TypeScript dependencies
         working-directory: ./memori-ts
         run: npm ci
@@ -236,4 +195,14 @@ jobs:
 
       - name: Publish @memorilabs/memori
         working-directory: ./memori-ts
-        run: npm publish --access public --tag beta
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            TAG="${VERSION#*-}"
+            TAG="${TAG%%.*}"
+          else
+            TAG="latest"
+          fi
+
+          npm publish --access public --tag "$TAG"

--- a/memori-ts/.npmignore
+++ b/memori-ts/.npmignore
@@ -15,6 +15,3 @@ examples/
 .env
 *.log
 .DS_Store
-
-# Exclude native binaries — users get these via optionalDependencies (@memori/native-*)
-**/*.node

--- a/memori-ts/package-lock.json
+++ b/memori-ts/package-lock.json
@@ -45,12 +45,6 @@
       "engines": {
         "node": ">=18.0.0"
       },
-      "optionalDependencies": {
-        "@memori/native-darwin-arm64": "0.1.5-beta",
-        "@memori/native-linux-arm64-gnu": "0.1.5-beta",
-        "@memori/native-linux-x64-gnu": "0.1.5-beta",
-        "@memori/native-win32-x64-msvc": "0.1.5-beta"
-      },
       "peerDependencies": {
         "@anthropic-ai/sdk": "*",
         "@google/genai": "*",
@@ -935,18 +929,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@memori/native-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@memori/native-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@memori/native-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@memori/native-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/@memorilabs/axon": {
       "version": "0.1.3",

--- a/memori-ts/package.json
+++ b/memori-ts/package.json
@@ -53,7 +53,7 @@
     "sequelize": "npm run build:dev && node dist/examples/orm/sequelize-mysql.js",
     "typeorm": "npm run build:dev && node dist/examples/orm/typeorm-sqlite.js",
     "mikro": "npm run build:dev && node dist/examples/orm/mikro-sqlite.js",
-    "prepublishOnly": "node scripts/sync-native.js --publish && npm run build"
+    "prepublishOnly": "node scripts/sync-native.js && npm run build"
   },
   "keywords": [
     "memori",
@@ -158,11 +158,5 @@
   },
   "dependencies": {
     "@memorilabs/axon": "^0.1.3"
-  },
-  "optionalDependencies": {
-    "@memori/native-linux-x64-gnu": "0.1.5-beta",
-    "@memori/native-linux-arm64-gnu": "0.1.5-beta",
-    "@memori/native-darwin-arm64": "0.1.5-beta",
-    "@memori/native-win32-x64-msvc": "0.1.5-beta"
   }
 }

--- a/memori-ts/scripts/sync-native.js
+++ b/memori-ts/scripts/sync-native.js
@@ -9,16 +9,13 @@ const RUST_BINDINGS_DIR = path.resolve(ROOT, '../core/bindings/node');
 const SRC_NATIVE = path.resolve(ROOT, 'src/native');
 const DIST_NATIVE = path.resolve(ROOT, 'dist/native');
 
-// --publish: omit .node binaries from the copy (platform packages provide them via optionalDependencies)
-const publishMode = process.argv.includes('--publish');
-
 function copyFolderSync(from, to) {
   if (!fs.existsSync(from)) return;
   if (fs.existsSync(to)) fs.rmSync(to, { recursive: true, force: true });
   fs.mkdirSync(to, { recursive: true });
 
   const files = fs.readdirSync(from);
-  const extensions = publishMode ? ['.js', '.d.ts'] : ['.js', '.d.ts', '.node'];
+  const extensions = ['.js', '.d.ts', '.node'];
 
   for (const file of files) {
     if (extensions.some((ext) => file.endsWith(ext))) {


### PR DESCRIPTION
- Renamed the `publish-native` job to `publish` for clarity and adjusted its steps to streamline the publishing process for the @memorilabs/memori package.
- Removed the installation of NAPI CLI and the creation of platform package scaffolding, simplifying the workflow.
- Updated the logic for copying native artifacts and publishing to dynamically set the npm tag based on the version.
- Removed optional dependencies for native packages from package.json and package-lock.json to simplify package management.
- Adjusted the sync-native script to always include .node files during the copy process, ensuring proper artifact handling.