### PR TITLE
Add macOS 15 Intel to the publish workflow matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,8 @@ jobs:
             archs: x86_64
           - os: ubuntu-24.04-arm
             archs: aarch64
+          - os: macos-15-intel
+            archs: x86_64
           - os: macos-14
             archs: arm64
           - os: windows-latest


### PR DESCRIPTION
- Updated the GitHub Actions publish workflow to include macOS 15 Intel as a new build target, enhancing cross-platform compatibility for the publishing process.