### PR TITLE
fix: sanitise recalled history to prevent tool-call corruption (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   responding to each 'tool_call_id'`. The OpenAI/Anthropic/Bedrock
   injection paths now sanitise recalled history before prepending it.
   Legacy Gemini-era `role="model"` rows are normalised to
-  `role="assistant"` for the same reason. (#434)
+  `role="assistant"` for the same reason. The injected-message counter
+  now tracks the post-sanitisation count so the post-response payload
+  does not slice into the current user message before persistence and
+  augmentation. (#434)
 
 ## [3.3.0rc1] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Conversation injection no longer corrupts OpenAI-compatible message
+  sequences for tool-using conversations. Recalled history previously
+  replayed `role="tool"` rows (with no `tool_call_id`) and empty
+  assistant rows (whose `tool_calls` were never persisted), causing
+  upstream providers to reject the request with `400: An assistant
+  message with 'tool_calls' must be followed by tool messages
+  responding to each 'tool_call_id'`. The OpenAI/Anthropic/Bedrock
+  injection paths now sanitise recalled history before prepending it.
+  Legacy Gemini-era `role="model"` rows are normalised to
+  `role="assistant"` for the same reason. (#434)
+
 ## [3.3.0rc1] - 2026-04-16
 
 ### Added

--- a/memori/llm/pipelines/conversation_injection.py
+++ b/memori/llm/pipelines/conversation_injection.py
@@ -18,9 +18,43 @@ from memori.llm._utils import (
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_history_for_openai_compat(
+    messages: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Strip recalled messages that would produce malformed tool-call
+    sequences when replayed to an OpenAI-compatible Chat Completions
+    endpoint.
+
+    The conversation_message schema stores only (role, content); the
+    tool_calls and tool_call_id fields are not persisted. Recalled
+    history of a tool-using turn would therefore inject:
+
+      - assistant messages with empty content (the original
+        tool_calls-only turn — its tool_calls field is lost), followed by
+      - role="tool" messages whose tool_call_id is lost.
+
+    OpenAI-compatible providers reject both ("An assistant message with
+    'tool_calls' must be followed by tool messages responding to each
+    'tool_call_id'"). Drop them here. Also normalise the legacy
+    Gemini-era role "model" to "assistant" so older rows replay cleanly.
+    """
+    cleaned: list[dict[str, str]] = []
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        if role == "tool":
+            continue
+        if role == "assistant" and not (content or "").strip():
+            continue
+        if role == "model":
+            role = "assistant"
+        cleaned.append({"role": role, "content": content})
+    return cleaned
+
+
 def _normalize_input_history(kwargs: dict, messages: list[dict[str, str]]) -> dict:
     history_items: list[dict[str, str]] = []
-    for msg in messages:
+    for msg in _sanitize_history_for_openai_compat(messages):
         role = msg.get("role", "user")
         content = msg.get("content", "")
         if role == "system":
@@ -62,13 +96,19 @@ def _inject_messages_by_provider(
         or agno_is_openai(config.framework.provider, config.llm.provider)
         or agno_is_xai(config.framework.provider, config.llm.provider)
     ):
-        kwargs["messages"] = messages + kwargs["messages"]
+        kwargs["messages"] = (
+            _sanitize_history_for_openai_compat(messages) + kwargs["messages"]
+        )
     elif (
         llm_is_anthropic(config.framework.provider, config.llm.provider)
         or llm_is_bedrock(config.framework.provider, config.llm.provider)
         or agno_is_anthropic(config.framework.provider, config.llm.provider)
     ):
-        filtered_messages = [m for m in messages if m.get("role") != "system"]
+        filtered_messages = [
+            m
+            for m in _sanitize_history_for_openai_compat(messages)
+            if m.get("role") != "system"
+        ]
         kwargs["messages"] = filtered_messages + kwargs["messages"]
     elif llm_is_xai(config.framework.provider, config.llm.provider):
         from xai_sdk.chat import assistant, user

--- a/memori/llm/pipelines/conversation_injection.py
+++ b/memori/llm/pipelines/conversation_injection.py
@@ -52,7 +52,9 @@ def _sanitize_history_for_openai_compat(
     return cleaned
 
 
-def _normalize_input_history(kwargs: dict, messages: list[dict[str, str]]) -> dict:
+def _normalize_input_history(
+    kwargs: dict, messages: list[dict[str, str]]
+) -> tuple[dict, int]:
     history_items: list[dict[str, str]] = []
     for msg in _sanitize_history_for_openai_compat(messages):
         role = msg.get("role", "user")
@@ -68,7 +70,7 @@ def _normalize_input_history(kwargs: dict, messages: list[dict[str, str]]) -> di
         existing_input = [{"role": "user", "content": existing_input}]
 
     kwargs["input"] = history_items + existing_input
-    return kwargs
+    return kwargs, len(history_items)
 
 
 def _normalize_google_contents(existing_contents):
@@ -87,7 +89,7 @@ def _normalize_google_contents(existing_contents):
 
 def _inject_messages_by_provider(
     config, kwargs: dict, messages: list[dict[str, str]]
-) -> dict:
+) -> tuple[dict, int]:
     if ("input" in kwargs or "instructions" in kwargs) and "messages" not in kwargs:
         return _normalize_input_history(kwargs, messages)
 
@@ -96,9 +98,9 @@ def _inject_messages_by_provider(
         or agno_is_openai(config.framework.provider, config.llm.provider)
         or agno_is_xai(config.framework.provider, config.llm.provider)
     ):
-        kwargs["messages"] = (
-            _sanitize_history_for_openai_compat(messages) + kwargs["messages"]
-        )
+        sanitized = _sanitize_history_for_openai_compat(messages)
+        kwargs["messages"] = sanitized + kwargs["messages"]
+        return kwargs, len(sanitized)
     elif (
         llm_is_anthropic(config.framework.provider, config.llm.provider)
         or llm_is_bedrock(config.framework.provider, config.llm.provider)
@@ -110,6 +112,7 @@ def _inject_messages_by_provider(
             if m.get("role") != "system"
         ]
         kwargs["messages"] = filtered_messages + kwargs["messages"]
+        return kwargs, len(filtered_messages)
     elif llm_is_xai(config.framework.provider, config.llm.provider):
         from xai_sdk.chat import assistant, user
 
@@ -123,6 +126,7 @@ def _inject_messages_by_provider(
                 xai_messages.append(assistant(content))
 
         kwargs["messages"] = xai_messages + kwargs["messages"]
+        return kwargs, len(xai_messages)
     elif llm_is_google(
         config.framework.provider, config.llm.provider
     ) or agno_is_google(config.framework.provider, config.llm.provider):
@@ -142,25 +146,28 @@ def _inject_messages_by_provider(
         else:
             existing_contents = _normalize_google_contents(kwargs.get("contents", []))
             kwargs["contents"] = contents + existing_contents
+        return kwargs, len(contents)
     else:
         raise NotImplementedError
-
-    return kwargs
 
 
 def inject_conversation_messages(invoke, kwargs: dict) -> dict:
     if invoke.config.cloud is True:
         messages = invoke._cloud_conversation_messages
-        invoke._injected_message_count = len(messages)
 
         if not messages:
+            invoke._injected_message_count = 0
             return kwargs
 
         logger.debug(
             "Injecting %d cloud conversation messages from history",
             len(messages),
         )
-        return _inject_messages_by_provider(invoke.config, kwargs, messages)
+        kwargs, injected_count = _inject_messages_by_provider(
+            invoke.config, kwargs, messages
+        )
+        invoke._injected_message_count = injected_count
+        return kwargs
 
     if invoke.config.storage is None or invoke.config.storage.driver is None:
         return kwargs
@@ -209,6 +216,9 @@ def inject_conversation_messages(invoke, kwargs: dict) -> dict:
     if not messages:
         return kwargs
 
-    invoke._injected_message_count = len(messages)
     logger.debug("Injecting %d conversation messages from history", len(messages))
-    return _inject_messages_by_provider(invoke.config, kwargs, messages)
+    kwargs, injected_count = _inject_messages_by_provider(
+        invoke.config, kwargs, messages
+    )
+    invoke._injected_message_count = injected_count
+    return kwargs

--- a/tests/llm/pipelines/test_conversation_injection.py
+++ b/tests/llm/pipelines/test_conversation_injection.py
@@ -1,4 +1,8 @@
+from types import SimpleNamespace
+
+from memori.llm._constants import OPENAI_LLM_PROVIDER
 from memori.llm.pipelines.conversation_injection import (
+    _inject_messages_by_provider,
     _sanitize_history_for_openai_compat,
 )
 
@@ -77,6 +81,56 @@ def test_sanitize_preserves_order():
 
 def test_sanitize_handles_empty_input():
     assert _sanitize_history_for_openai_compat([]) == []
+
+
+def _openai_config():
+    return SimpleNamespace(
+        framework=SimpleNamespace(provider=None),
+        llm=SimpleNamespace(provider=OPENAI_LLM_PROVIDER),
+    )
+
+
+def test_inject_returns_post_sanitization_count_for_tool_call_history():
+    """4 rows in (user, empty assistant, tool, final assistant) but only 2
+    survive sanitization. The returned count must reflect what was actually
+    prepended, otherwise the downstream slice in _exclude_injected_messages
+    will eat the current user message.
+    """
+    messages = [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {"role": "assistant", "content": ""},
+        {"role": "tool", "content": '{"temp": 12}'},
+        {"role": "assistant", "content": "It's 12C in Paris."},
+    ]
+    kwargs = {"messages": [{"role": "user", "content": "and in Berlin?"}]}
+
+    kwargs, injected_count = _inject_messages_by_provider(
+        _openai_config(), kwargs, messages
+    )
+
+    assert injected_count == 2
+    assert kwargs["messages"][injected_count:] == [
+        {"role": "user", "content": "and in Berlin?"}
+    ]
+    assert kwargs["messages"][:injected_count] == [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {"role": "assistant", "content": "It's 12C in Paris."},
+    ]
+
+
+def test_inject_count_matches_message_count_when_nothing_filtered():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    kwargs = {"messages": [{"role": "user", "content": "next"}]}
+
+    kwargs, injected_count = _inject_messages_by_provider(
+        _openai_config(), kwargs, messages
+    )
+
+    assert injected_count == 2
+    assert len(kwargs["messages"]) == 3
 
 
 def test_sanitize_handles_missing_role_and_content():

--- a/tests/llm/pipelines/test_conversation_injection.py
+++ b/tests/llm/pipelines/test_conversation_injection.py
@@ -1,0 +1,94 @@
+from memori.llm.pipelines.conversation_injection import (
+    _sanitize_history_for_openai_compat,
+)
+
+
+def test_sanitize_drops_role_tool():
+    messages = [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {"role": "assistant", "content": ""},
+        {"role": "tool", "content": '{"temp": 12}'},
+        {"role": "assistant", "content": "It's 12C in Paris."},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert cleaned == [
+        {"role": "user", "content": "what's the weather in Paris?"},
+        {"role": "assistant", "content": "It's 12C in Paris."},
+    ]
+
+
+def test_sanitize_drops_empty_assistant():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+        {"role": "assistant", "content": "   "},
+        {"role": "assistant", "content": "hello!"},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert cleaned == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello!"},
+    ]
+
+
+def test_sanitize_rewrites_legacy_model_role():
+    messages = [
+        {"role": "user", "content": "ping"},
+        {"role": "model", "content": "pong"},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert cleaned == [
+        {"role": "user", "content": "ping"},
+        {"role": "assistant", "content": "pong"},
+    ]
+
+
+def test_sanitize_preserves_user_and_system():
+    messages = [
+        {"role": "system", "content": "you are helpful"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert cleaned == messages
+
+
+def test_sanitize_preserves_order():
+    messages = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "tool", "content": "d"},
+        {"role": "assistant", "content": "e"},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert [m["content"] for m in cleaned] == ["a", "b", "c", "e"]
+
+
+def test_sanitize_handles_empty_input():
+    assert _sanitize_history_for_openai_compat([]) == []
+
+
+def test_sanitize_handles_missing_role_and_content():
+    messages = [
+        {"content": "no role defaults to user"},
+        {"role": "assistant"},
+        {"role": "user"},
+    ]
+
+    cleaned = _sanitize_history_for_openai_compat(messages)
+
+    assert cleaned == [
+        {"role": "user", "content": "no role defaults to user"},
+        {"role": "user", "content": ""},
+    ]


### PR DESCRIPTION
## Summary

Fixes the first bug reported in #434: Memori's conversation-injection
pipeline corrupts the message sequence when recalled history is replayed
into a tool-using OpenAI-compatible request, causing upstream providers
to reject the call with a 400.

## Authorship

Authored by Claude (Anthropic) with human oversight and verification.
The fix has been running in our production deployment for several days
under human review before submission.

## Root cause

`memori_conversation_message` stores only `(role, content)` —
`tool_calls` and `tool_call_id` are not persisted. On recall:

- assistant turns whose original payload was `tool_calls`-only are
  replayed as `{role: "assistant", content: ""}`
- tool turns are replayed as `{role: "tool", content: "<result>"}`
  with no `tool_call_id`

OpenAI-compatible providers reject both:

> `BadRequestError: 400 - An assistant message with 'tool_calls' must
> be followed by tool messages responding to each 'tool_call_id'.`

This breaks any agent loop that uses tool calling after the first
recall.

## Fix

This PR implements **Option A** from the issue: sanitise recalled
history at injection time, dropping rows that would produce malformed
sequences.

`_sanitize_history_for_openai_compat()` drops `role="tool"` and empty
`assistant` rows, and rewrites legacy `role="model"` (Gemini-era) to
`role="assistant"`. It is called from the OpenAI/Anthropic/Bedrock
branches of `_inject_messages_by_provider` and from
`_normalize_input_history` (the Responses-API path). The xAI and Google
branches already use their own role filters and content shapes, so they
are left untouched.

**Trade-off:** prior tool *results* are not recalled into prompts.
They were not usable anyway without `tool_call_id`, and fact extraction
still runs over user + assistant content, so the recall signal that
matters (extracted facts, user-volunteered context, assistant
summaries) is preserved.

## Out of scope

The issue also notes a second bug — `anthropic/_adapter.py::get_formatted_response`
crashing on `tool_use` content blocks. That fix is not in this PR;
filing it separately keeps the changes focused.

## Verification

- 7 new unit tests in `tests/llm/pipelines/test_conversation_injection.py`
  covering: drops `role="tool"`, drops empty assistant, rewrites
  `model`→`assistant`, preserves user/system, preserves order, handles
  empty input, handles missing `role`/`content` keys.
- Full unit suite: **861 passed**.
- `uv run ruff format .` and `uv run ruff check .` clean.
- Production verification: this fix has been running for several days
  in our deployment (n8n AI Agent → Memori → MiniMax-M2.7 over an
  OpenAI-compatible endpoint, with `date_time` / `perplexity_research` /
  `OpenWeatherMap` tools). 7+ turn tool-using conversations that
  previously broke at turn 3-4 now run cleanly with cross-turn fact
  recall intact.

## Changelog

Added entry under `[Unreleased]` → `Fixed`.