### PR TITLE
fix: count sanitized injected messages

### DIFF
--- a/tests/llm/pipelines/test_conversation_injection.py
+++ b/tests/llm/pipelines/test_conversation_injection.py
@@ -1,9 +1,12 @@
 from types import SimpleNamespace
 
+from memori._config import Config
+from memori.llm._base import BaseInvoke
 from memori.llm._constants import OPENAI_LLM_PROVIDER
 from memori.llm.pipelines.conversation_injection import (
     _inject_messages_by_provider,
     _sanitize_history_for_openai_compat,
+    inject_conversation_messages,
 )
 
 
@@ -146,3 +149,28 @@ def test_sanitize_handles_missing_role_and_content():
         {"role": "user", "content": "no role defaults to user"},
         {"role": "user", "content": ""},
     ]
+
+
+def test_injected_count_uses_sanitized_message_count(mocker):
+    config = Config()
+    config.cache.conversation_id = 123
+    config.llm.provider = OPENAI_LLM_PROVIDER
+    config.storage = mocker.Mock()
+    config.storage.driver = mocker.Mock()
+    config.storage.driver.conversation.messages.read.return_value = [
+        {"role": "user", "content": "Weather in Tokyo?"},
+        {"role": "assistant", "content": ""},
+        {"role": "tool", "content": '{"temp": "21C"}'},
+        {"role": "assistant", "content": "It is 21C."},
+    ]
+    invoke = BaseInvoke(config, "test_method")
+    kwargs = {"messages": [{"role": "user", "content": "What should I pack?"}]}
+
+    result = inject_conversation_messages(invoke, kwargs)
+
+    assert result["messages"] == [
+        {"role": "user", "content": "Weather in Tokyo?"},
+        {"role": "assistant", "content": "It is 21C."},
+        {"role": "user", "content": "What should I pack?"},
+    ]
+    assert invoke._injected_message_count == 2


### PR DESCRIPTION
## Summary
- Builds on #436 by tracking the number of messages actually prepended after provider-specific sanitization/filtering.
- Prevents post-response payload slicing from dropping the current user message when tool-call history rows are removed.
- Adds a regression test for recalled tool-call history where 4 stored rows sanitize down to 2 injected messages.

## Test plan
- `uv run ruff format memori/llm/pipelines/conversation_injection.py tests/llm/pipelines/test_conversation_injection.py`
- `uv run pytest tests/llm/pipelines/test_conversation_injection.py tests/llm/test_llm_base.py::test_inject_conversation_messages_openai_success tests/llm/test_llm_base.py::test_inject_conversation_messages_cloud_fetches_from_cloud`
- `uv run ruff check memori/llm/pipelines/conversation_injection.py tests/llm/pipelines/test_conversation_injection.py`


Made with [Cursor](https://cursor.com)