### PR TITLE
fix: sanitize TypeScript recalled history

### DIFF
--- a/memori-ts/src/engines/recall.ts
+++ b/memori-ts/src/engines/recall.ts
@@ -12,6 +12,33 @@ import {
 } from '../utils/utils.js';
 import { CloudRecallResponse, ParsedFact } from '../types/api.js';
 
+type RawHistoryMessage = {
+  role?: unknown;
+  content?: unknown;
+  text?: unknown;
+};
+
+function sanitizeHistoryMessages(
+  messages: RawHistoryMessage[],
+  options: { dropSystem?: boolean } = {}
+): Message[] {
+  const sanitized: Message[] = [];
+
+  for (const message of messages) {
+    const roleValue = message.role === 'model' ? 'assistant' : message.role;
+    const role = typeof roleValue === 'string' ? roleValue : 'user';
+    const content = stringifyContent(message.content ?? message.text);
+
+    if (options.dropSystem && role === 'system') continue;
+    if (role === 'tool') continue;
+    if (role === 'assistant' && !content.trim()) continue;
+
+    sanitized.push({ role: role as Role, content });
+  }
+
+  return sanitized;
+}
+
 /**
  * Retrieves relevant memories and injects them into the LLM system prompt before each call.
  *
@@ -73,10 +100,7 @@ export class RecallEngine {
         if (this.config.storage) {
           const rawHistory = await this.config.storage.getConversationHistory(sessionId);
 
-          historyMessages = rawHistory.map((m) => ({
-            role: m.role as Role,
-            content: m.content,
-          }));
+          historyMessages = sanitizeHistoryMessages(rawHistory);
         }
       } catch (e) {
         console.warn('Local Recall Hook failed:', e);
@@ -161,14 +185,9 @@ export class RecallEngine {
     };
     const response = await this.api.post<CloudRecallResponse>('cloud/recall', payload);
     const facts = extractFacts(response);
-    const history = (
-      extractHistory(response) as Array<{ role: Role; content?: unknown; text?: string }>
-    )
-      .filter((m) => m.role !== 'system')
-      .map((m) => ({
-        role: m.role,
-        content: stringifyContent(m.content ?? m.text),
-      }));
+    const history = sanitizeHistoryMessages(extractHistory(response) as RawHistoryMessage[], {
+      dropSystem: true,
+    });
     return { facts, history };
   }
 }

--- a/memori-ts/src/engines/recall.ts
+++ b/memori-ts/src/engines/recall.ts
@@ -20,7 +20,7 @@ type RawHistoryMessage = {
 
 function sanitizeHistoryMessages(
   messages: RawHistoryMessage[],
-  options: { dropSystem?: boolean } = {}
+  dropSystem = false
 ): Message[] {
   const sanitized: Message[] = [];
 
@@ -29,7 +29,7 @@ function sanitizeHistoryMessages(
     const role = typeof roleValue === 'string' ? roleValue : 'user';
     const content = stringifyContent(message.content ?? message.text);
 
-    if (options.dropSystem && role === 'system') continue;
+    if (dropSystem && role === 'system') continue;
     if (role === 'tool') continue;
     if (role === 'assistant' && !content.trim()) continue;
 
@@ -185,9 +185,10 @@ export class RecallEngine {
     };
     const response = await this.api.post<CloudRecallResponse>('cloud/recall', payload);
     const facts = extractFacts(response);
-    const history = sanitizeHistoryMessages(extractHistory(response) as RawHistoryMessage[], {
-      dropSystem: true,
-    });
+    const history = sanitizeHistoryMessages(
+      extractHistory(response) as RawHistoryMessage[],
+      true
+    );
     return { facts, history };
   }
 }

--- a/memori-ts/tests/engines/recall.test.ts
+++ b/memori-ts/tests/engines/recall.test.ts
@@ -95,6 +95,32 @@ describe('RecallEngine', () => {
       expect(newReq.messages[0].content).toBe('past msg');
     });
 
+    it('should sanitize malformed tool-call history returned by the API', async () => {
+      (mockApi.post as any).mockResolvedValue({
+        facts: [],
+        messages: [
+          { role: 'user', content: 'Weather in Tokyo?' },
+          { role: 'assistant', content: '' },
+          { role: 'tool', content: '{"temp": "21C"}' },
+          { role: 'assistant', content: 'It is 21C.' },
+          { role: 'model', content: 'Legacy model response.' },
+        ],
+      });
+
+      const req = {
+        messages: [{ role: 'user', content: 'What should I pack?' }],
+      } as unknown as LLMRequest;
+
+      const newReq = await recallEngine.handleRecall(req, {} as any);
+
+      expect(newReq.messages).toEqual([
+        { role: 'user', content: 'Weather in Tokyo?' },
+        { role: 'assistant', content: 'It is 21C.' },
+        { role: 'assistant', content: 'Legacy model response.' },
+        { role: 'user', content: 'What should I pack?' },
+      ]);
+    });
+
     it('should fail silently and return original request on API error', async () => {
       (mockApi.post as any).mockRejectedValue(new Error('Network fail'));
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -228,6 +254,30 @@ describe('RecallEngine', () => {
       expect(newReq.messages[0]).toEqual({ role: 'user', content: 'prior question' });
       expect(newReq.messages[1]).toEqual({ role: 'assistant', content: 'prior answer' });
       expect(mockApi.post).not.toHaveBeenCalled();
+    });
+
+    it('should sanitize malformed tool-call history from local storage', async () => {
+      const mockGetHistory = vi.fn().mockResolvedValue([
+        { role: 'user', content: 'Weather in Tokyo?' },
+        { role: 'assistant', content: '' },
+        { role: 'tool', content: '{"temp": "21C"}' },
+        { role: 'assistant', content: 'It is 21C.' },
+      ]);
+      (mockNativeEngine as any).hasStorage = true;
+      (mockConfig as any).storage = { getConversationHistory: mockGetHistory };
+      (mockNativeEngine.retrieve as any).mockReturnValue([]);
+
+      const req = {
+        messages: [{ role: 'user', content: 'What should I pack?' }],
+      } as unknown as LLMRequest;
+
+      const newReq = await recallEngine.handleRecall(req, {} as any);
+
+      expect(newReq.messages).toEqual([
+        { role: 'user', content: 'Weather in Tokyo?' },
+        { role: 'assistant', content: 'It is 21C.' },
+        { role: 'user', content: 'What should I pack?' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Sanitizes recalled conversation history in the TypeScript SDK before prepending it to LLM requests.
- Drops orphan `role=\"tool\"` messages and empty assistant rows that lost tool-call metadata, and normalizes legacy `model` rows to `assistant`.
- Covers both cloud-returned history and BYODB/local storage history.

## Test plan
- `npm test -- tests/engines/recall.test.ts`
- `npm run typecheck`
- `npm run format:check -- src/engines/recall.ts tests/engines/recall.test.ts`
- `npm run lint -- src/engines/recall.ts tests/engines/recall.test.ts`